### PR TITLE
Adds new route for database metadata

### DIFF
--- a/python/valis/db/models.py
+++ b/python/valis/db/models.py
@@ -128,10 +128,10 @@ class PipesModel(PeeweeBase):
 
 class DbMetadata(PeeweeBase):
     """ Pydantic response model for the db metadata """
-    schema: str
-    table_name: str
-    column_name: str
-    display_name: str
-    description: str
-    unit: Optional[str] = None
-    sql_type: Optional[str] = None
+    schema: str = Field(..., description='the database schema name')
+    table_name: str = Field(..., description='the database table name')
+    column_name: str = Field(..., description='the database column name')
+    display_name: str = Field(..., description='a human-readable display name for the column')
+    description: str = Field(..., description='a description of the database column')
+    unit: Optional[str] = Field(None, description='the unit if any for the database column')
+    sql_type: Optional[str] = Field(None, description='the data type of the column')

--- a/python/valis/db/models.py
+++ b/python/valis/db/models.py
@@ -126,4 +126,12 @@ class PipesModel(PeeweeBase):
     astra: Optional[dict] = None
 
 
-
+class DbMetadata(PeeweeBase):
+    """ Pydantic response model for the db metadata """
+    schema: str
+    table_name: str
+    column_name: str
+    display_name: str
+    description: str
+    unit: Optional[str] = None
+    sql_type: Optional[str] = None

--- a/python/valis/db/queries.py
+++ b/python/valis/db/queries.py
@@ -476,3 +476,25 @@ def get_target_cartons(sdss_id: int) -> peewee.ModelSelect:
         join(targetdb.CartonToTarget).join(targetdb.Carton).where(vizdb.SDSSidFlat.sdss_id == sdss_id).\
         order_by(targetdb.Carton.run_on, vizdb.SDSSidFlat.catalogid)
 
+
+def get_db_metadata(schema: str = None) -> peewee.ModelSelect:
+    """ Get the sdss5db database metadata
+
+    Get the sdss5db database table and column metadata.
+    By default returns all schema, but a specific one can be
+    specified with the ``schema`` keyword.
+
+    Parameters
+    ----------
+    schema : str, optional
+        the database schema name, by default None
+
+    Returns
+    -------
+    peewee.ModelSelect
+        the output query
+    """
+    query = vizdb.DbMetadata.select()
+    if schema:
+        query = query.where(vizdb.DbMetadata.schema == schema)
+    return query


### PR DESCRIPTION
Adds a new valis endpoint at `/valis/info/database` to retrieve the `sdss5db` database metadata from the `vizdb.db_metadata` table.  This endpoint provides the descriptions of all the database columns.  