### PR TITLE
Return targets with spectra by observatory

### DIFF
--- a/python/valis/db/queries.py
+++ b/python/valis/db/queries.py
@@ -306,8 +306,9 @@ def get_targets_obs(release: str, obs: str, obsWave: str) -> peewee.ModelSelect:
         return query_boss
     elif obsWave == 'apogee':
         # temportary, just return some sdss_id
-        return query = vizdb.SDSSidStacked.select()\
-                                          .where(vizdb.SDSSidStacked.sdss_id << sdss_id_ap)
+        query = vizdb.SDSSidStacked.select()\
+                                   .where(vizdb.SDSSidStacked.sdss_id << sdss_id_ap)
+        return query
     else:
         raise ValueError('Did not pass "boss", "apogee" or "all" to obsWave')
 

--- a/python/valis/db/queries.py
+++ b/python/valis/db/queries.py
@@ -284,8 +284,11 @@ def get_targets_obs(release: str, obs: str, obsWave: str) -> peewee.ModelSelect:
     peewee.ModelSelect
         the ORM query
     """
-    # get the relevant software tag
+    # get the relevant software tag boss
     run2d = get_software_tag(release, 'run2d')
+
+    # get the relevant software tag apogee
+    apred = get_software_tag(release, 'apred_vers')
 
     if obsWave == 'boss':
         query = vizdb.SDSSidStacked.select()\
@@ -293,6 +296,13 @@ def get_targets_obs(release: str, obs: str, obsWave: str) -> peewee.ModelSelect:
                                          on=(boss.BossSpectrum.sdss_id == vizdb.SDSSidStacked.sdss_id))\
                                    .where(boss.BossSpectrum.run2d == run2d,
                                           boss.BossSpectrum.obs == obs).distinct()
+    elif obsWave == 'apogee':
+        query_ap = apo.Star.select().\
+                           .where(apo.Star.telescope == obs.lower() + '25m',
+                                  apo.Star.apred_vers == apred)
+        # temportary, just return some sdss_id
+        query = vizdb.SDSSidStacked.select()\
+                                   .where(vizdb.SDSSidStacked.sdss_id == 3350466)
     return query
 
 

--- a/python/valis/db/queries.py
+++ b/python/valis/db/queries.py
@@ -264,6 +264,38 @@ def carton_program_search(name: str, name_type: str) -> peewee.ModelSelect:
     )
 
 
+def get_targets_obs(release: str, obs: str, obsWave: str) -> peewee.ModelSelect:
+    """ Return all targets with spectra from a given observatory
+
+    Parameters
+    ----------
+    release : str
+        the data release to look up
+
+    obs: str
+        Observatory to get targets from. Either 'APO' or 'LCO'
+
+    obsWave: str
+        Which spectrograph to return data from. Can be 'boss',
+        'apogee' or 'all' for both.
+
+    Returns
+    -------
+    peewee.ModelSelect
+        the ORM query
+    """
+    # get the relevant software tag
+    run2d = get_software_tag(release, 'run2d')
+
+    if obsWave == 'boss':
+        query = vizdb.SDSSidStacked.select()\
+                                   .join(boss.BossSpectrum,
+                                         on=(boss.BossSpectrum.sdss_id == vizdb.SDSSidStacked.sdss_id))\
+                                   .where(boss.BossSpectrum.run2d == run2d,
+                                          boss.BossSpectrum.obs == obs).distinct()
+    return query
+
+
 # test sdss ids
 # 23326 - boss/astra
 # 3350466 - apogee/astra

--- a/python/valis/db/queries.py
+++ b/python/valis/db/queries.py
@@ -264,7 +264,7 @@ def carton_program_search(name: str, name_type: str) -> peewee.ModelSelect:
     )
 
 
-def get_targets_obs(release: str, obs: str, obsWave: str) -> peewee.ModelSelect:
+def get_targets_obs(release: str, obs: str, spectrograph: str) -> peewee.ModelSelect:
     """ Return all targets with spectra from a given observatory
 
     Parameters
@@ -275,7 +275,7 @@ def get_targets_obs(release: str, obs: str, obsWave: str) -> peewee.ModelSelect:
     obs: str
         Observatory to get targets from. Either 'APO' or 'LCO'
 
-    obsWave: str
+    spectrograph: str
         Which spectrograph to return data from. Can be 'boss',
         'apogee' or 'all' for both.
 
@@ -310,11 +310,11 @@ def get_targets_obs(release: str, obs: str, obsWave: str) -> peewee.ModelSelect:
                                    .where((vizdb.SDSSidStacked.sdss_id << query_boss) |
                                           (vizdb.SDSSidStacked.sdss_id << query_ap))
 
-    if obsWave == 'boss':
+    if spectrograph == 'boss':
         return query_boss
-    elif obsWave == 'apogee':
+    elif spectrograph == 'apogee':
         return query_ap
-    elif obsWave == 'all':
+    elif spectrograph == 'all':
         return query_all
     else:
         raise ValueError('Did not pass "boss", "apogee" or "all" to obsWave')

--- a/python/valis/db/queries.py
+++ b/python/valis/db/queries.py
@@ -296,14 +296,14 @@ def get_targets_obs(release: str, obs: str, obsWave: str) -> peewee.ModelSelect:
     # get the relevant software tag apogee
     apred = get_software_tag(release, 'apred_vers')
 
-    # temporary, need to join with sdss_id
-    query_ap = apo.Star.select()\
-                       .where(apo.Star.telescope == obs.lower() + '25m',
-                              apo.Star.apred_vers == apred)
-    # temportary, just return some sdss_id
-    sdss_id_ap = [3350466]
+    # temporary, need to join with sdss_id when added
     query_ap = vizdb.SDSSidStacked.select()\
-                                  .where(vizdb.SDSSidStacked.sdss_id << sdss_id_ap)
+                                  .join(vizdb.SDSSidFlat,
+                                        on=(vizdb.SDSSidFlat.sdss_id == vizdb.SDSSidStacked.sdss_id))\
+                                  .join(apo.Star,
+                                        on=(apo.Star.catalogid == vizdb.SDSSidFlat.catalogid))\
+                                  .where(apo.Star.telescope == obs.lower() + '25m',
+                                         apo.Star.apred_vers == apred).distinct()
 
     # return union of the above
     query_all = vizdb.SDSSidStacked.select()\

--- a/python/valis/db/queries.py
+++ b/python/valis/db/queries.py
@@ -300,19 +300,24 @@ def get_targets_obs(release: str, obs: str, obsWave: str) -> peewee.ModelSelect:
     query_ap = apo.Star.select()\
                        .where(apo.Star.telescope == obs.lower() + '25m',
                               apo.Star.apred_vers == apred)
+    # temportary, just return some sdss_id
     sdss_id_ap = [3350466]
+    query_ap = vizdb.SDSSidStacked.select()\
+                                  .where(vizdb.SDSSidStacked.sdss_id << sdss_id_ap)
+
+    # return union of the above
+    query_all = vizdb.SDSSidStacked.select()\
+                                   .where((vizdb.SDSSidStacked.sdss_id << query_boss) |
+                                          (vizdb.SDSSidStacked.sdss_id << query_ap))
 
     if obsWave == 'boss':
         return query_boss
     elif obsWave == 'apogee':
-        # temportary, just return some sdss_id
-        query = vizdb.SDSSidStacked.select()\
-                                   .where(vizdb.SDSSidStacked.sdss_id << sdss_id_ap)
-        return query
+        return query_ap
+    elif obsWave == 'all':
+        return query_all
     else:
         raise ValueError('Did not pass "boss", "apogee" or "all" to obsWave')
-
-    return query
 
 
 # test sdss ids

--- a/python/valis/routes/query.py
+++ b/python/valis/routes/query.py
@@ -156,11 +156,11 @@ class QueryRoutes(Base):
                                  Query(enum=['APO', 'LCO'],
                                        description='Observatory to get targets from. Either "APO" or "LCO"',
                                        example='APO')] = 'APO',
-                  obsWave: Annotated[str,
-                                     Query(enum=['boss', 'apogee', 'all'],
-                                           description='Which spectrograph to return data from',
-                                           example='boss')] = 'boss'):
+                  spectrograph: Annotated[str,
+                                          Query(enum=['boss', 'apogee', 'all'],
+                                                description='Which spectrograph to return data from',
+                                                example='boss')] = 'boss'):
         """ Perform a search on carton or program """
 
-        return list(get_targets_obs(release, obs, obsWave))
+        return list(get_targets_obs(release, obs, spectrograph))
 

--- a/python/valis/routes/query.py
+++ b/python/valis/routes/query.py
@@ -13,7 +13,8 @@ from valis.db.db import get_pw_db
 from valis.db.models import SDSSidStackedBase, SDSSidPipesBase
 from valis.db.queries import (cone_search, append_pipes, carton_program_search,
                               carton_program_list, carton_program_map,
-                              get_targets_by_sdss_id, get_targets_by_catalog_id)
+                              get_targets_by_sdss_id, get_targets_by_catalog_id,
+                              get_targets_obs)
 
 
 class SearchCoordUnits(str, Enum):
@@ -146,4 +147,20 @@ class QueryRoutes(Base):
         """ Perform a search on carton or program """
 
         return list(carton_program_search(name, name_type))
+
+    @router.get('/obs', summary='Return targets with spectrum at observatory',
+                response_model=List[SDSSidStackedBase], dependencies=[Depends(get_pw_db)])
+    async def obs(self,
+                  release: Annotated[str, Query(description='Data release to query', example='IPL3')],
+                  obs: Annotated[str,
+                                 Query(enum=['APO', 'LCO'],
+                                       description='Observatory to get targets from. Either "APO" or "LCO"',
+                                       example='APO')] = 'APO',
+                  obsWave: Annotated[str,
+                                     Query(enum=['boss', 'apogee', 'all'],
+                                           description='Which spectrograph to return data from',
+                                           example='boss')] = 'boss'):
+        """ Perform a search on carton or program """
+
+        return list(get_targets_obs(release, obs, obsWave))
 


### PR DESCRIPTION
This adds the feature to return the list of targets with spectra at some observatory. Currently the query works by specifying a data release, an observatory and an instrument.

For just searching on BOSS or APOGEE spectra, the queries seem optimized enough I think (~4.5 sec for BOSS and ~2 sec for APOGEE at APO). Doing the union of both instruments takes much longer (~45 sec). The bottleneck here seems to be sequential scanning from looking at the query plan. I tried to turn this off and test it again, but the query plan says it still uses sequential scanning even after doing this. So, I am unsure what do do about this bit of the feature.