### PR TITLE
Adds support for apStar and mwmStar files 

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -5462,13 +5462,13 @@ docs = ["Sphinx (>=7.2.0)", "importlib-metadata (>=1.6.0)", "jinja2 (<3.1)", "re
 
 [[package]]
 name = "sdssdb"
-version = "0.8.0"
+version = "0.9.0"
 description = "SDSS product for database management"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "sdssdb-0.8.0-py3-none-any.whl", hash = "sha256:500d660e5c5b2657b970e89d9d769d77a61c20a43feaa3be85f035d615edad56"},
-    {file = "sdssdb-0.8.0.tar.gz", hash = "sha256:d85b2d7bb09a7005cb4d5bd53cef3495c8fa77c7012fba0e7e0504aaf734b0a7"},
+    {file = "sdssdb-0.9.0-py3-none-any.whl", hash = "sha256:80912115ae83966e9205bd679e8811b0c12ca2951fe00e374b143b02eca741a9"},
+    {file = "sdssdb-0.9.0.tar.gz", hash = "sha256:dccd137aef234a7257e4c25fca6280f961492dd868d813ecf89838e21942ae17"},
 ]
 
 [package.dependencies]
@@ -5479,14 +5479,14 @@ pgpasslib = ">=1.1.0"
 psycopg2-binary = ">=2.7.7"
 pygments = "*"
 pyyaml = ">=5.1"
-sdsstools = ">=0.1.11"
+sdsstools = ">=0.1.0"
 six = ">=1.12.0"
 sqlalchemy = ">=1.3.6"
 
 [package.extras]
 all = ["astropy (>=4.0.0)", "inflect (>=4.1.0)", "pandas (>=1.0.0)", "progressbar2 (>=3.46.1)", "pydot (>=1.4.1)"]
 dev = ["astropy (>=4.0.0)", "factory-boy (>=2.12.0)", "ipdb (>=0.13.2)", "ipython (>=7.13.0)", "pydot (>=1.4.2)", "pytest (>=5.2)", "pytest-cov (>=2.4.0)", "pytest-factoryboy (>=2.0.3)", "pytest-postgresql (>=2.2.1)", "pytest-sugar (>=0.8.0)"]
-docs = ["Sphinx (>=3.0.0,<4.0.0)", "jinja2 (==3.0.0)", "sphinx-bootstrap-theme (>=0.4.12)"]
+docs = ["Sphinx (>=7.0.0)", "releases (>=2.0.0)", "sphinx-bootstrap-theme (>=0.4.12)"]
 
 [[package]]
 name = "sdsstools"
@@ -7000,4 +7000,4 @@ docs = ["Sphinx"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "4e0de40f870ccd526abf1c699994e495bfa15c239fe45d909979cba07a092483"
+content-hash = "fc69fa1a558584b4d40dd0b5581b3d658a589924008d7a75609e2554cb010419"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ httpx = "^0.24.0"
 astroquery = "^0.4.6"
 pandas = "^1.5.3"
 SQLAlchemy = "^1.4.35"
-sdssdb = "^0.8.0"
+sdssdb = "^0.9.0"
 sdss-solara = {git = "https://github.com/sdss/sdss_solara.git"}
 
 

--- a/python/valis/db/db.py
+++ b/python/valis/db/db.py
@@ -60,7 +60,7 @@ def connect_db(db, orm: str = 'peewee'):
     return db
 
 # local local dev
-pdb.connect_from_parameters(dbname='sdss5db', host='localhost', port=6000, user='u0857802')
+# pdb.connect_from_parameters(dbname='sdss5db', host='localhost', port=6000, user='u0857802')
 
 def get_pw_db(db_state=Depends(reset_db_state)):
     """ Dependency to connect a database with peewee """

--- a/python/valis/db/db.py
+++ b/python/valis/db/db.py
@@ -59,6 +59,8 @@ def connect_db(db, orm: str = 'peewee'):
 
     return db
 
+# local local dev
+pdb.connect_from_parameters(dbname='sdss5db', host='localhost', port=6000, user='u0857802')
 
 def get_pw_db(db_state=Depends(reset_db_state)):
     """ Dependency to connect a database with peewee """
@@ -83,5 +85,3 @@ def get_sqla_db():
     finally:
         if db:
             db.close()
-
-

--- a/python/valis/db/models.py
+++ b/python/valis/db/models.py
@@ -5,9 +5,19 @@
 # all resuable Pydantic models of the ORMs go here
 
 import datetime
-from typing import Optional
-from pydantic import ConfigDict, BaseModel, Field
+import math
+from typing import Optional, Annotated, Any, TypeVar
+from pydantic import ConfigDict, BaseModel, Field, BeforeValidator
 
+
+def coerce_nan_to_none(x: Any) -> Any:
+    if x and math.isnan(x):
+        return None
+    return x
+
+T = TypeVar('T')
+
+FloatNaN = Annotated[Optional[T], BeforeValidator(coerce_nan_to_none)]
 
 # for how to specify required, optional, default, etc, see
 # https://docs.pydantic.dev/latest/migration/#required-optional-and-nullable-fields
@@ -85,6 +95,81 @@ class BossSpectrum(PeeweeBase):
     objtype: str = None
     specobjid: int = None
 
+class AstraSource(PeeweeBase):
+    """ Pydantic response model for the MWM Astra source metadata """
+    sdss_id: int = None
+    sdss4_apogee_id: Optional[int] = None
+    gaia_dr2_source_id: Optional[int] = None
+    gaia_dr3_source_id: Optional[int] = None
+    tic_v8_id: Optional[int] = None
+    healpix: int = None
+    n_associated: int = None
+    n_neighborhood: int = None
+    sdss4_apogee_target1_flags: int = None
+    sdss4_apogee_target2_flags: int = None
+    sdss4_apogee2_target1_flags: int = None
+    sdss4_apogee2_target2_flags: int = None
+    sdss4_apogee2_target3_flags: int = None
+    sdss4_apogee_member_flags: int = None
+    sdss4_apogee_extra_target_flags: int = None
+    ra: float = None
+    dec: float = None
+    n_boss_visits: int = None
+    n_apogee_visits: int = None
+    l: float = None
+    b: float = None
+    ebv: float = None
+    e_ebv: float = None
+    gaia_v_rad: FloatNaN[float] = None
+    gaia_e_v_rad: FloatNaN[float] = None
+    g_mag: FloatNaN[float] = None
+    bp_mag: FloatNaN[float] = None
+    rp_mag: FloatNaN[float] = None
+    j_mag: FloatNaN[float] = None
+    e_j_mag: FloatNaN[float] = None
+    h_mag: FloatNaN[float] = None
+    e_h_mag: FloatNaN[float] = None
+    k_mag: FloatNaN[float] = None
+    e_k_mag: FloatNaN[float] = None
+
+class ApogeeStar(PeeweeBase):
+    """ Pydantic response model for the MWM Apogee DRP pipeline star metadata """
+    apogee_id: str = None
+    file: str = None
+    uri: str = None
+    starver: int = None
+    mjdbeg: int = None
+    mjdend: int = None
+    telescope: str = None
+    apred_vers: str = None
+    healpix: int = None
+    snr: float = None
+    ra: float = None
+    dec: float = None
+    glon: float = None
+    glat: float = None
+    jmag: float = None
+    jerr: float = None
+    hmag: float = None
+    herr: float = None
+    kmag: float = None
+    kerr: float = None
+    src_h: str = None
+    apogee_target1: int = None
+    apogee_target2: int = None
+    apogee2_target1: int = None
+    apogee2_target2: int = None
+    apogee2_target3: int = None
+    apogee2_target4: int = None
+    catalogid: int = None
+    gaiadr2_sourceid: int = None
+    firstcarton: str = None
+    targflags: str = None
+    nvisits: int = None
+    ngoodvisits: int = None
+    ngoodrvs: int = None
+    starflag: int = None
+    starflags: str = None
 
 class CatalogModel(PeeweeBase):
     """ Pydantic model for source catalog information """
@@ -129,8 +214,8 @@ class PipeFiles(BaseModel):
 class PipesModel(PeeweeBase):
     """ Pydantic model for pipeline metadata """
     boss: Optional[BossSpectrum] = None
-    apogee: Optional[dict] = None
-    astra: Optional[dict] = None
+    apogee: Optional[ApogeeStar] = None
+    astra: Optional[AstraSource] = None
     files: Optional[PipeFiles] = None
 
 

--- a/python/valis/db/queries.py
+++ b/python/valis/db/queries.py
@@ -560,7 +560,7 @@ def _yield_boss_spectrum(sdss_id: int, product: str, release: str) -> Generator:
 
 
 def _yield_apogee_spectrum(sdss_id: int, product: str, release: str) -> Generator:
-    """ Yield a apogee spectrum
+    """ Yield an apogee spectrum
 
     Yield the apogee spectral data for a given target sdss_id and data release,
     and a SDSS data product, i.e. sdss_access path name.
@@ -588,8 +588,8 @@ def _yield_apogee_spectrum(sdss_id: int, product: str, release: str) -> Generato
             yield None
 
 
-def _yield_astra_spectrum(sdss_id: int, product: str, release: str) -> Generator:
-    """ Yield a astra spectrum
+def _yield_astra_spectrum(sdss_id: int, product: str, release: str, ext: str) -> Generator:
+    """ Yield an astra spectrum
 
     Yield the astra spectral data for a given target sdss_id and data release,
     and a SDSS data product, i.e. sdss_access path name.
@@ -602,6 +602,8 @@ def _yield_astra_spectrum(sdss_id: int, product: str, release: str) -> Generator
         the name of the SDSS data product
     release : str
         the SDSS data release
+    ext : str
+        the name of spectral extension
 
     Yields
     -------
@@ -612,12 +614,12 @@ def _yield_astra_spectrum(sdss_id: int, product: str, release: str) -> Generator
     for row in query.dicts().iterator():
         filepath = build_astra_path(row, release)
         try:
-            yield extract_data(product, filepath)
+            yield extract_data(product, filepath, multispec=ext)
         except FileNotFoundError:
             yield None
 
 
-def get_a_spectrum(sdss_id: int, product: str, release: str) -> Generator:
+def get_a_spectrum(sdss_id: int, product: str, release: str, ext: str = None) -> Generator:
     """ Yield a spectrum
 
     Yield the spectral data for a given target sdss_id and data release,
@@ -631,6 +633,8 @@ def get_a_spectrum(sdss_id: int, product: str, release: str) -> Generator:
         the name of the SDSS data product
     release : str
         the SDSS data release
+    ext : str
+        the name of the spectral extension, e.g. BOSS/APO
 
     Yields
     -------
@@ -643,7 +647,7 @@ def get_a_spectrum(sdss_id: int, product: str, release: str) -> Generator:
     elif model['pipeline'] == 'apogee':
         yield from _yield_apogee_spectrum(sdss_id, product, release)
     elif model['pipeline'] == 'astra':
-        yield from _yield_astra_spectrum(sdss_id, product, release)
+        yield from _yield_astra_spectrum(sdss_id, product, release, ext=ext)
 
 
 def get_catalog_sources(sdss_id: int) -> peewee.ModelSelect:

--- a/python/valis/io/model_spectra_info.json
+++ b/python/valis/io/model_spectra_info.json
@@ -2,6 +2,7 @@
     {
         "product": "specLite",
         "aliases": ["specFull", "spec-lite", "spec"],
+        "pipeline": "boss",
         "multi_spectra": false,
         "parameters": {
             "flux": {"extension": 1, "type": "table", "column": "FLUX", "units": "1e-17 * erg / (s * cm**2 * Angstrom)"},
@@ -13,6 +14,7 @@
     {
         "product": "apStar",
         "aliases": ["apstar"],
+        "pipeline": "apogee",
         "multi_spectra": false,
         "parameters": {
             "flux": {"extension": 1, "type": "image", "column": "FLUX", "units": "1e-17 * erg / (s * cm**2 * Angstrom)"},
@@ -24,6 +26,7 @@
     {
         "product": "mwmStar",
         "aliases": ["mwmstar"],
+        "pipeline": "astra",
         "multi_spectra": true,
         "spectral_extensions": ["BOSS/APO", "BOSS/LCO", "APOGEE/APO", "APOGEE/LCO"],
         "parameters": {

--- a/python/valis/io/model_spectra_info.json
+++ b/python/valis/io/model_spectra_info.json
@@ -2,11 +2,35 @@
     {
         "product": "specLite",
         "aliases": ["specFull", "spec-lite", "spec"],
+        "multi_spectra": false,
         "parameters": {
             "flux": {"extension": 1, "type": "table", "column": "FLUX", "units": "1e-17 * erg / (s * cm**2 * Angstrom)"},
             "wavelength": {"extension": 1, "type": "table", "column": "LOGLAM", "units": "Angstrom"},
             "error": {"extension": 1, "type": "table", "column": "IVAR"},
             "mask": {"extension": 1, "type": "table", "column": "OR_MASK"}
+        }
+    },
+    {
+        "product": "apStar",
+        "aliases": ["apstar"],
+        "multi_spectra": false,
+        "parameters": {
+            "flux": {"extension": 1, "type": "image", "column": "FLUX", "units": "1e-17 * erg / (s * cm**2 * Angstrom)"},
+            "wavelength": {"extension": 0, "type": "wcs", "column": "LOGLAM", "nwave": 8575, "units": "Angstrom"},
+            "error": {"extension": 2, "type": "image", "column": "ERROR", "units": "1e-17 * erg / (s * cm**2 * Angstrom)"},
+            "mask": {"extension": 3, "type": "image", "column": "MASK"}
+        }
+    },
+    {
+        "product": "mwmStar",
+        "aliases": ["mwmstar"],
+        "multi_spectra": true,
+        "spectral_extensions": ["BOSS/APO", "BOSS/LCO", "APOGEE/APO", "APOGEE/LCO"],
+        "parameters": {
+            "flux": {"extension": 1, "type": "table", "column": "flux", "units": "1e-17 * erg / (s * cm**2 * Angstrom)"},
+            "wavelength": {"extension": 1, "type": "table", "column": "wavelength", "units": "Angstrom"},
+            "error": {"extension": 1, "type": "table", "column": "ivar"},
+            "mask": {"extension": 1, "type": "table", "column": "pixel_flags"}
         }
     }
 ]

--- a/python/valis/io/spectra.py
+++ b/python/valis/io/spectra.py
@@ -5,6 +5,7 @@
 import pathlib
 import json
 from functools import lru_cache
+from typing import Union
 
 import astropy.units as u
 from astropy.io import fits
@@ -46,7 +47,7 @@ def get_product_model(product: str) -> dict:
     return prod[0] if prod else None
 
 
-def extract_data(product: str, filepath: str, multispec: int | str = None) -> dict:
+def extract_data(product: str, filepath: str, multispec: Union[int, str] = None) -> dict:
     """ Extract spectral data from a file
 
     Extract the spectral data for a given data product

--- a/python/valis/routes/info.py
+++ b/python/valis/routes/info.py
@@ -23,7 +23,7 @@ except ImportError:
     SDSSDataModel = None
     Phases = Surveys = Releases = Tags = ProductModel = SchemaModel = None
 
-from valis.db.db import get_pw_db, pdb
+from valis.db.db import get_pw_db
 from valis.db.models import DbMetadata
 from valis.db.queries import get_db_metadata
 from valis.routes.base import Base, release
@@ -139,7 +139,7 @@ class DataModels(Base):
         return product[0].get_schema()
 
     @router.get('/database', summary='Retrieve sdss5db database table and column metadata',
-                #dependencies=[Depends(get_pw_db)],
+                dependencies=[Depends(get_pw_db)],
                 response_model=Dict[str, Dict[str, DbMetadata]])
     async def get_dbmetadata(self, schema: Annotated[str, Query(description='The sdss5db database schema name', example='targetdb')] = None):
         """ Get the sdss5db database table and column metadata """

--- a/python/valis/routes/info.py
+++ b/python/valis/routes/info.py
@@ -23,7 +23,7 @@ except ImportError:
     SDSSDataModel = None
     Phases = Surveys = Releases = Tags = ProductModel = SchemaModel = None
 
-from valis.db.db import get_pw_db
+from valis.db.db import get_pw_db, pdb
 from valis.db.models import DbMetadata
 from valis.db.queries import get_db_metadata
 from valis.routes.base import Base, release
@@ -139,7 +139,7 @@ class DataModels(Base):
         return product[0].get_schema()
 
     @router.get('/database', summary='Retrieve sdss5db database table and column metadata',
-                dependencies=[Depends(get_pw_db)],
+                #dependencies=[Depends(get_pw_db)],
                 response_model=Dict[str, Dict[str, DbMetadata]])
     async def get_dbmetadata(self, schema: Annotated[str, Query(description='The sdss5db database schema name', example='targetdb')] = None):
         """ Get the sdss5db database table and column metadata """

--- a/python/valis/routes/query.py
+++ b/python/valis/routes/query.py
@@ -70,7 +70,8 @@ class QueryRoutes(Base):
     #         filter(vizdb.SDSSidStacked.cone_search(ra, dec, radius, ra_col='ra_sdss_id', dec_col='dec_sdss_id')).all()
 
     @router.post('/main', summary='Main query for the UI or combining queries',
-                 response_model=MainSearchResponse, dependencies=[Depends(get_pw_db)])
+                 dependencies=[Depends(get_pw_db)],
+                 response_model=MainSearchResponse)
     async def main_search(self, body: SearchModel):
         """ Main query for UI and for combining queries together """
 
@@ -177,4 +178,3 @@ class QueryRoutes(Base):
         """ Perform a search on carton or program """
 
         return list(get_targets_obs(release, obs, spectrograph))
-

--- a/python/valis/routes/target.py
+++ b/python/valis/routes/target.py
@@ -14,9 +14,7 @@ from astroquery.simbad import Simbad
 
 from valis.routes.base import Base
 from valis.db.queries import (get_target_meta, get_a_spectrum, get_catalog_sources,
-                              get_target_cartons, get_boss_target, get_apogee_target,
-                              get_astra_target, build_boss_path, build_apogee_path,
-                              build_astra_path)
+                              get_target_cartons, get_target_pipeline)
 from valis.db.db import get_pw_db
 from valis.db.models import CatalogResponse, CartonModel, PipesModel, SDSSModel
 
@@ -202,23 +200,4 @@ class Target(Base):
                                                  description='Specify search on specific pipeline',
                                                  example='boss')] = 'all'):
 
-        boss = get_boss_target(sdss_id, self.release) or {}
-        apogee = get_apogee_target(sdss_id, self.release) or {}
-        astra = get_astra_target(sdss_id, self.release) or {}
-        boss = boss.dicts().first() if boss else {}
-        apogee = apogee.dicts().first() if apogee else {}
-        astra = astra.dicts().first() if astra else {}
-
-        if pipe == 'boss':
-            return {'boss': boss, 'files': {'boss': build_boss_path(boss, self.release)}}
-        if pipe == 'apogee':
-            return {'apogee': apogee, 'files': {'apogee': build_apogee_path(apogee, self.release)}}
-        if pipe == 'astra':
-            return {'astra': astra, 'files': {'astra': build_astra_path(astra, self.release)}}
-
-        return {'boss': boss,
-                'apogee': apogee,
-                'astra': astra,
-                'files': {'boss': build_boss_path(boss, self.release),
-                          'apogee': build_apogee_path(apogee, self.release),
-                          'astra': build_astra_path(astra, self.release)}}
+        return get_target_pipeline(sdss_id, self.release, pipe)

--- a/python/valis/routes/target.py
+++ b/python/valis/routes/target.py
@@ -171,8 +171,9 @@ class Target(Base):
                 response_model=List[SpectrumModel])
     async def get_spectrum(self, sdss_id: Annotated[int, Path(title="The sdss_id of the target to get", example=23326)],
                            product: Annotated[str, Query(description='The file species or data product name', example='specLite')],
+                           ext: Annotated[str, Query(description='For multi-extension spectra, e.g. mwmStar, the name of the spectral extension', example='BOSS/APO')] = None,
                            ):
-        return get_a_spectrum(sdss_id, product, self.release)
+        return get_a_spectrum(sdss_id, product, self.release, ext=ext)
 
     @router.get('/catalogs/{sdss_id}', summary='Retrieve catalog information for a target sdss_id',
                 dependencies=[Depends(get_pw_db)],

--- a/python/valis/routes/target.py
+++ b/python/valis/routes/target.py
@@ -17,7 +17,7 @@ from valis.db.queries import (get_target_meta, get_a_spectrum, get_catalog_sourc
                               get_target_cartons, get_boss_target, get_apogee_target,
                               get_astra_target, build_boss_path, build_apogee_path,
                               build_astra_path)
-from valis.db.db import get_pw_db, pdb
+from valis.db.db import get_pw_db
 from valis.db.models import CatalogResponse, CartonModel, PipesModel, SDSSModel
 
 router = APIRouter()
@@ -161,7 +161,7 @@ class Target(Base):
         return res.to_pandas().to_dict('records')
 
     @router.get('/ids/{sdss_id}', summary='Retrieve pipeline metadata for a target sdss_id',
-                #dependencies=[Depends(get_pw_db)],
+                dependencies=[Depends(get_pw_db)],
                 response_model=Union[SDSSModel, dict],
                 response_model_exclude_unset=True, response_model_exclude_none=True)
     async def get_target(self, sdss_id: int = Path(title="The sdss_id of the target to get", example=23326)):
@@ -169,7 +169,7 @@ class Target(Base):
         return get_target_meta(sdss_id, self.release) or {}
 
     @router.get('/spectra/{sdss_id}', summary='Retrieve a spectrum for a target sdss_id',
-                #dependencies=[Depends(get_pw_db)],
+                dependencies=[Depends(get_pw_db)],
                 response_model=List[SpectrumModel])
     async def get_spectrum(self, sdss_id: Annotated[int, Path(title="The sdss_id of the target to get", example=23326)],
                            product: Annotated[str, Query(description='The file species or data product name', example='specLite')],
@@ -177,7 +177,7 @@ class Target(Base):
         return get_a_spectrum(sdss_id, product, self.release)
 
     @router.get('/catalogs/{sdss_id}', summary='Retrieve catalog information for a target sdss_id',
-                #dependencies=[Depends(get_pw_db)],
+                dependencies=[Depends(get_pw_db)],
                 response_model=List[CatalogResponse],
                 response_model_exclude_unset=True, response_model_exclude_none=True)
     async def get_catalogs(self, sdss_id: int = Path(title="The sdss_id of the target to get", example=23326)):
@@ -185,7 +185,7 @@ class Target(Base):
         return get_catalog_sources(sdss_id).dicts().iterator()
 
     @router.get('/cartons/{sdss_id}', summary='Retrieve carton information for a target sdss_id',
-                #dependencies=[Depends(get_pw_db)],
+                dependencies=[Depends(get_pw_db)],
                 response_model=List[CartonModel],
                 response_model_exclude_unset=True, response_model_exclude_none=True)
     async def get_cartons(self, sdss_id: int = Path(title="The sdss_id of the target to get", example=23326)):
@@ -193,7 +193,7 @@ class Target(Base):
         return get_target_cartons(sdss_id).dicts().iterator()
 
     @router.get('/pipelines/{sdss_id}', summary='Retrieve pipeline data for a target sdss_id',
-                #dependencies=[Depends(get_pw_db)],
+                dependencies=[Depends(get_pw_db)],
                 response_model=PipesModel,
                 response_model_exclude_unset=True)
     async def get_pipeline(self, sdss_id: int = Path(title="The sdss_id of the target to get", example=23326),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,9 @@ import pytest
 from valis.utils.paths import build_boss_path, build_apogee_path, build_file_path
 
 
+datamodel = pytest.importorskip("datamodel")
+
+
 boss_res = {'field': 15078, 'mjd': 59187, 'run2d': 'v6_1_2', 'obs': 'APO',
             'nexp': 4, 'catalogid': 4291570940, 'sdss_id': 54392544}
 astra_res = {'sdss_id': 54392544, 'catalogid': 27021597850854486, 'v_astra': '0.5.0'}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,41 @@
+
+# encoding: utf-8
+#
+import pytest
+
+from valis.utils.paths import build_boss_path, build_apogee_path, build_file_path
+
+
+boss_res = {'field': 15078, 'mjd': 59187, 'run2d': 'v6_1_2', 'obs': 'APO',
+            'nexp': 4, 'catalogid': 4291570940, 'sdss_id': 54392544}
+astra_res = {'sdss_id': 54392544, 'catalogid': 27021597850854486, 'v_astra': '0.5.0'}
+apogee_res = {'apogee_id': '2M00104221+5744297', 'starver': '59953', 'telescope': 'apo25m',
+              'apred_vers': '1.2', 'healpix': 14966}
+
+
+@pytest.mark.parametrize('lite', [True, False])
+def test_build_boss_path(lite):
+    """ test we can create a boss spec path """
+    path = build_boss_path(boss_res, 'IPL3', lite=lite, ignore_existence=True)
+    assert 'sas/ipl-3/spectro/boss/redux/' in path
+    ll = 'lite' if lite else 'full'
+    assert f'spectra/{ll}/015078/59187/spec-015078-59187-4291570940.fits' in path
+
+
+def test_build_apstar_path():
+    """ test we can create a apogee apstar path """
+    path = build_apogee_path(apogee_res, "IPL3", ignore_existence=True)
+    assert 'ipl-3/spectro/apogee/redux/1.2/stars/apo25m' in path
+    assert '2M00104221+5744297' in path
+
+
+def test_build_file_path():
+    """ test we can create a astra mwmstar path """
+    path = build_file_path(astra_res, 'mwmStar', 'IPL3', defaults={'component': ''}, ignore_existence=True)
+    assert 'sas/ipl-3/spectro/astra/0.5.0/spectra' in path
+    assert '25/44/mwmStar-0.5.0-54392544.fits' in path
+
+def test_build_fails():
+    """ test build filepath fails correctly """
+    with pytest.raises(ValueError, match="Not all path keywords found in model fields or tags: ['component']*"):
+        build_file_path(astra_res, 'mwmStar', 'IPL3', ignore_existence=True)


### PR DESCRIPTION
This PR adds support getting pipeline metadata for apogee and astra, using the astra and apogee ORMs, along with the associated spectra filepaths and/or the spectral data.  This PR only includes support for apStar and mwmStar files.  
