### PR TITLE
Modify carton_program_search to accept initial query

### DIFF
--- a/python/valis/db/queries.py
+++ b/python/valis/db/queries.py
@@ -256,7 +256,7 @@ def carton_program_search(name: str,
         Which type you are searching on, either 'carton' or 'program'
     query : ModelSelect
         An initial query to extend. If ``None``, a new query with all the unique
-        ``sdss_id``s is created (note: this is probably a bad idea).
+        ``sdss_id``s is created.
 
     Returns
     -------

--- a/python/valis/db/queries.py
+++ b/python/valis/db/queries.py
@@ -265,7 +265,7 @@ def carton_program_search(name: str,
     """
 
     if query is None:
-        query = vizdb.SDSSidFlat.select(peewee.fn.DISTINCT(vizdb.SDSSidFlat.sdss_id))
+        query = vizdb.SDSSidStacked.select(peewee.fn.DISTINCT(vizdb.SDSSidStacked.sdss_id))
 
     query = (query.join(
                 vizdb.SDSSidFlat,
@@ -753,7 +753,7 @@ def get_paged_target_list_by_mapper(mapper: MapperName = MapperName.MWM, page_nu
     peewee.ModelSelect
         the ORM query
     """
-    
+
     if mapper is MapperName.MWM:
         where_condition = vizdb.SDSSidToPipes.in_apogee == True
     elif mapper is MapperName.BHM:

--- a/python/valis/routes/query.py
+++ b/python/valis/routes/query.py
@@ -92,9 +92,10 @@ class QueryRoutes(Base):
             query = get_targets_by_sdss_id(body.id)
 
         # build the program/carton query
-        elif body.program or body.carton:
-            query = carton_program_search(body.program or body.carton, 'program' if body.program else 'carton')
-
+        if body.program or body.carton:
+            query = carton_program_search(body.program or body.carton,
+                                          'program' if body.program else 'carton',
+                                          query=query)
         # append query to pipes
         query = append_pipes(query)
 


### PR DESCRIPTION
Fixes #20

Modifies `carton_program_search` to appenth the carton/program filter to an input query. The `query/main` route backend now sends the initial query (cone search or sdss_id-based) to `carton_program_search`.

I think this is ready for review, but while testing this against the `pipelines` DB I found some inconsistencies that I don't understand. I'll add them here but this may be a different issue/bug.

If I do a request to `/query/main` with parameters

```json
{
  "ra": 315.01417,
  "dec": 45.299,
  "radius": 0.1,
  "units": "degree",
  "id": 23326,
  "program": "mwm_gg"
}
```

I get the following response

```json
{
  "status": "success",
  "msg": "data successfully retrieved",
  "data": [
    {
      "sdss_id": 68024942,
      "ra_sdss_id": 315.05084411121544,
      "dec_sdss_id": 45.20588033521532,
      "catalogid21": 4220994466,
      "catalogid25": 27021597780505884,
      "catalogid31": 63050395029375420,
      "in_boss": false,
      "in_apogee": false,
      "in_astra": false
    },
    {
      "sdss_id": 68024943,
      "ra_sdss_id": 315.062827092735,
      "dec_sdss_id": 45.21487254418657,
      "catalogid21": 4220994932,
      "catalogid25": 27021597780506348,
      "catalogid31": 63050395029375460,
      "in_boss": false,
      "in_apogee": false,
      "in_astra": false
    },
    {
      "sdss_id": 68024961,
      "ra_sdss_id": 315.09597354158774,
      "dec_sdss_id": 45.27862222819132,
      "catalogid21": 4220997447,
      "catalogid25": 27021597780508864,
      "catalogid31": 63050395029376104,
      "in_boss": false,
      "in_apogee": false,
      "in_astra": false
    },
    {
      "sdss_id": 68024987,
      "ra_sdss_id": 314.95347840004644,
      "dec_sdss_id": 45.216076160585764,
      "catalogid21": 4220994710,
      "catalogid25": 27021597780506130,
      "catalogid31": 63050395029376960,
      "in_boss": false,
      "in_apogee": false,
      "in_astra": false
    },
    {
      "sdss_id": 68025009,
      "ra_sdss_id": 314.94202956896544,
      "dec_sdss_id": 45.23171132283618,
      "catalogid21": 4220995714,
      "catalogid25": 27021597780507132,
      "catalogid31": 63050395029377660,
      "in_boss": false,
      "in_apogee": false,
      "in_astra": false
    },
    {
      "sdss_id": 68025016,
      "ra_sdss_id": 314.89990763754577,
      "dec_sdss_id": 45.270289766329235,
      "catalogid21": 4220996144,
      "catalogid25": 27021597780507560,
      "catalogid31": 63050395029377930,
      "in_boss": false,
      "in_apogee": true,
      "in_astra": true
    },
    {
      "sdss_id": 68025018,
      "ra_sdss_id": 314.89693109761066,
      "dec_sdss_id": 45.27824207067139,
      "catalogid21": 4221000580,
      "catalogid25": 27021597780511990,
      "catalogid31": 63050395029377960,
      "in_boss": false,
      "in_apogee": false,
      "in_astra": false
    },
    {
      "sdss_id": 68025019,
      "ra_sdss_id": 315.00491792931393,
      "dec_sdss_id": 45.202994234609825,
      "catalogid21": 4220994499,
      "catalogid25": 27021597780505916,
      "catalogid31": 63050395029377980,
      "in_boss": false,
      "in_apogee": false,
      "in_astra": false
    },
    {
      "sdss_id": 68025024,
      "ra_sdss_id": 315.0335240455252,
      "dec_sdss_id": 45.243782636228346,
      "catalogid21": 4220995289,
      "catalogid25": 27021597780506704,
      "catalogid31": 63050395029378100,
      "in_boss": false,
      "in_apogee": false,
      "in_astra": false
    },
    {
      "sdss_id": 68025031,
      "ra_sdss_id": 315.0008232677731,
      "dec_sdss_id": 45.27332492307533,
      "catalogid21": 4220996357,
      "catalogid25": 27021597780507776,
      "catalogid31": 63050395029378420,
      "in_boss": false,
      "in_apogee": false,
      "in_astra": false
    },
    {
      "sdss_id": 68025035,
      "ra_sdss_id": 315.04050094391545,
      "dec_sdss_id": 45.265637026700745,
      "catalogid21": 4220996374,
      "catalogid25": 27021597780507790,
      "catalogid31": 63050395029378510,
      "in_boss": false,
      "in_apogee": false,
      "in_astra": false
    },
    {
      "sdss_id": 68025038,
      "ra_sdss_id": 315.06185546679467,
      "dec_sdss_id": 45.30014261435378,
      "catalogid21": 4220998720,
      "catalogid25": 27021597780510136,
      "catalogid31": 63050395029378660,
      "in_boss": false,
      "in_apogee": false,
      "in_astra": false
    },
    {
      "sdss_id": 68025046,
      "ra_sdss_id": 314.9601099202946,
      "dec_sdss_id": 45.26546724961669,
      "catalogid21": 4220996549,
      "catalogid25": 27021597780507970,
      "catalogid31": 63050395029379060,
      "in_boss": false,
      "in_apogee": true,
      "in_astra": true
    },
    {
      "sdss_id": 68025050,
      "ra_sdss_id": 314.9717849168135,
      "dec_sdss_id": 45.29245137188428,
      "catalogid21": 4220996722,
      "catalogid25": 27021597780508136,
      "catalogid31": 63050395029379240,
      "in_boss": false,
      "in_apogee": false,
      "in_astra": false
    },
    {
      "sdss_id": 68025052,
      "ra_sdss_id": 314.91147854099677,
      "dec_sdss_id": 45.287862738192686,
      "catalogid21": 4221001109,
      "catalogid25": 27021597780512520,
      "catalogid31": 63050395029379380,
      "in_boss": false,
      "in_apogee": false,
      "in_astra": false
    },
    {
      "sdss_id": 68025055,
      "ra_sdss_id": 314.961038303085,
      "dec_sdss_id": 45.323149633427676,
      "catalogid21": 4221001406,
      "catalogid25": 27021597780512816,
      "catalogid31": 63050395029379460,
      "in_boss": false,
      "in_apogee": false,
      "in_astra": false
    },
    {
      "sdss_id": 68025060,
      "ra_sdss_id": 315.03812617377923,
      "dec_sdss_id": 45.346884016876224,
      "catalogid21": 4221003535,
      "catalogid25": 27021597780514944,
      "catalogid31": 63050395029379760,
      "in_boss": false,
      "in_apogee": false,
      "in_astra": false
    },
    {
      "sdss_id": 68025063,
      "ra_sdss_id": 315.0109459811423,
      "dec_sdss_id": 45.36783499184685,
      "catalogid21": 4221003973,
      "catalogid25": 27021597780515380,
      "catalogid31": 63050395029380030,
      "in_boss": false,
      "in_apogee": false,
      "in_astra": false
    },
    {
      "sdss_id": 68025193,
      "ra_sdss_id": 315.1012441652457,
      "dec_sdss_id": 45.32288809841765,
      "catalogid21": 4220998956,
      "catalogid25": 27021597780510370,
      "catalogid31": 63050395029385690,
      "in_boss": false,
      "in_apogee": false,
      "in_astra": false
    },
    {
      "sdss_id": 68025197,
      "ra_sdss_id": 315.11669853225345,
      "dec_sdss_id": 45.3534231499345,
      "catalogid21": 4220999976,
      "catalogid25": 27021597780511388,
      "catalogid31": 63050395029385910,
      "in_boss": false,
      "in_apogee": false,
      "in_astra": false
    },
    {
      "sdss_id": 68025198,
      "ra_sdss_id": 315.1219170037156,
      "dec_sdss_id": 45.359593784411366,
      "catalogid21": 4220999981,
      "catalogid25": 27021597780511390,
      "catalogid31": 63050395029385910,
      "in_boss": false,
      "in_apogee": true,
      "in_astra": true
    },
    {
      "sdss_id": 68025383,
      "ra_sdss_id": 314.92181922071006,
      "dec_sdss_id": 45.36748657355299,
      "catalogid21": 4221005047,
      "catalogid25": 27021597780516456,
      "catalogid31": 63050395029393650,
      "in_boss": false,
      "in_apogee": false,
      "in_astra": false
    }
  ]
}
```

This corresponds to the query 

```postgresql
SELECT DISTINCT ON ("t1"."sdss_id") "t2"."sdss_id", "t2"."catalogid21", "t2"."catalogid25", "t2"."catalogid31", "t2"."ra_sdss_id", "t2"."dec_sdss_id", "t1"."in_boss", "t1"."in_apogee", "t1"."in_astra" FROM "vizdb"."sdss_id_stacked" AS "t2" INNER JOIN "vizdb"."sdss_id_flat" AS "t3" ON ("t3"."sdss_id" = "t2"."sdss_id") INNER JOIN "targetdb"."target" AS "t4" ON ("t4"."catalogid" = "t3"."catalogid") INNER JOIN "targetdb"."carton_to_target" AS "t5" ON ("t5"."target_pk" = "t4"."pk") INNER JOIN "targetdb"."carton" AS "t6" ON ("t5"."carton_pk" = "t6"."pk") INNER JOIN "vizdb"."sdssid_to_pipes" AS "t1" ON ("t2"."sdss_id" = "t1"."sdss_id") WHERE (q3c_radial_query("t2"."ra_sdss_id", "t2"."dec_sdss_id", 315.01417, 45.299, 0.1) AND ("t6"."program" = 'mwm_gg'))
```

which I print just before the route returns (after the `append_to_pipes()` call). This looks fine, however the same query when run in `sdss5db` in the `pipelines` machine returns

```plaintext
 sdss_id  | catalogid21 |    catalogid25    |    catalogid31    |     ra_sdss_id     |    dec_sdss_id     | in_boss | in_apogee | in_astra
----------+-------------+-------------------+-------------------+--------------------+--------------------+---------+-----------+----------
 68024942 |  4220994466 | 27021597780505885 | 63050395029375424 | 315.05084411121544 |  45.20588033521532 | f       | f         | f
 68024943 |  4220994932 | 27021597780506349 | 63050395029375456 |   315.062827092735 |  45.21487254418657 | f       | f         | f
 68024961 |  4220997447 | 27021597780508863 | 63050395029376102 | 315.09597354158774 |  45.27862222819132 | f       | f         | f
 68024987 |  4220994710 | 27021597780506128 | 63050395029376964 | 314.95347840004644 | 45.216076160585764 | f       | f         | f
 68025009 |  4220995714 | 27021597780507131 | 63050395029377668 | 314.94202956896544 |  45.23171132283618 | f       | f         | f
 68025016 |  4220996144 | 27021597780507561 | 63050395029377931 | 314.89990763754577 | 45.270289766329235 | f       | t         | t
 68025018 |  4221000580 | 27021597780511993 | 63050395029377962 | 314.89693109761066 |  45.27824207067139 | f       | f         | f
 68025019 |  4220994499 | 27021597780505917 | 63050395029377984 | 315.00491792931393 | 45.202994234609825 | f       | f         | f
 68025024 |  4220995289 | 27021597780506706 | 63050395029378098 |  315.0335240455252 | 45.243782636228346 | f       | f         | f
 68025031 |  4220996357 | 27021597780507774 | 63050395029378419 |  315.0008232677731 |  45.27332492307533 | f       | f         | f
 68025035 |  4220996374 | 27021597780507791 | 63050395029378513 | 315.04050094391545 | 45.265637026700745 | f       | f         | f
 68025038 |  4220998720 | 27021597780510134 | 63050395029378656 | 315.06185546679467 |  45.30014261435378 | f       | f         | f
 68025046 |  4220996549 | 27021597780507966 | 63050395029379057 |  314.9601099202946 |  45.26546724961669 | f       | t         | t
 68025050 |  4220996722 | 27021597780508138 | 63050395029379243 |  314.9717849168135 |  45.29245137188428 | f       | f         | f
 68025052 |  4221001109 | 27021597780512521 | 63050395029379376 | 314.91147854099677 | 45.287862738192686 | f       | f         | f
 68025055 |  4221001406 | 27021597780512818 | 63050395029379452 |   314.961038303085 | 45.323149633427676 | f       | f         | f
 68025060 |  4221003535 | 27021597780514943 | 63050395029379757 | 315.03812617377923 | 45.346884016876224 | f       | f         | f
 68025063 |  4221003973 | 27021597780515381 | 63050395029380030 |  315.0109459811423 |  45.36783499184685 | f       | f         | f
 68025193 |  4220998956 | 27021597780510370 | 63050395029385690 |  315.1012441652457 |  45.32288809841765 | f       | f         | f
 68025197 |  4220999976 | 27021597780511389 | 63050395029385913 | 315.11669853225345 |   45.3534231499345 | f       | f         | f
 68025198 |  4220999981 | 27021597780511394 | 63050395029385914 |  315.1219170037156 | 45.359593784411366 | f       | t         | t
 68025383 |  4221005047 | 27021597780516455 | 63050395029393648 | 314.92181922071006 |  45.36748657355299 | f       | f         | f
```

Note that the `sdss_id` and `catalogid21` seem to match the API response, but the `catalogid25` and `catalogid31` are different (although not by much, which maybe indicates these are duplicates somehow).

The same query in `Zora` returns a table with the same results of the request JSON dump.

One thing I notice is that although I specified release `IPL3` that does not appear in the query, although maybe that's expected for this query.