### PR TITLE
chore: allow development without DB reconnection

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Change Log
 * Adds endpoints for target search by sdss_id and catalogid
 * Adds endpoints for listing cartons and programs
 * Adds endpoints for target search by carton and program
+* Adds ``db_reset`` option to avoid closing and resetting the database connection
 
 0.1.0 (10-24-2023)
 ------------------
@@ -25,4 +26,3 @@ Change Log
 * Adds endpoint for downloading or streaming FITS file data
 * Adds endpoint for accessing ``tree`` and ``sdss_access`` environment and path info
 * Sets up main FastAPI architecture
-

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ db_port: 6000
 db_user: {unid}
 ```
 
+Additionally, you can set the environment variable `DB_RESET=false` or add `db_reset: false` to `valis.yaml`. This will prevent the DB connection to be closed after a query completes and should speed up new queries. This setting should not be used in production.
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ db_port: 6000
 db_user: {unid}
 ```
 
-Additionally, you can set the environment variable `DB_RESET=false` or add `db_reset: false` to `valis.yaml`. This will prevent the DB connection to be closed after a query completes and should speed up new queries. This setting should not be used in production.
+Additionally, you can set the environment variable `VALIS_DB_RESET=false` or add `db_reset: false` to `valis.yaml`. This will prevent the DB connection to be closed after a query completes and should speed up new queries. This setting should not be used in production.
 
 ## Deployment
 

--- a/python/valis/__init__.py
+++ b/python/valis/__init__.py
@@ -2,6 +2,11 @@
 
 from sdsstools import get_config, get_logger, get_package_version
 
+import sdssdb
+
+sdssdb.autoconnect = False
+
+
 # pip package name
 NAME = 'sdss-valis'
 

--- a/python/valis/db/db.py
+++ b/python/valis/db/db.py
@@ -64,9 +64,6 @@ def connect_db(db, orm: str = 'peewee'):
 
     return db
 
-# local local dev
-# pdb.connect_from_parameters(dbname='sdss5db', host='localhost', port=6000, user='u0857802')
-
 def get_pw_db():
     """ Dependency to connect a database with peewee """
 

--- a/python/valis/db/db.py
+++ b/python/valis/db/db.py
@@ -5,9 +5,10 @@
 from contextvars import ContextVar
 
 import peewee
-from fastapi import Depends, HTTPException
+from fastapi import HTTPException
 from sdssdb.peewee.sdss5db import database as pdb
 from sdssdb.sqlalchemy.sdss5db import database as sdb
+
 
 # To make Peewee async-compatible, we need to hack the peewee connection state
 # See FastAPI/Peewee docs at https://fastapi.tiangolo.com/how-to/sql-databases-peewee/
@@ -17,7 +18,7 @@ db_state_default = {"closed": None, "conn": None, "ctx": None, "transactions": N
 db_state = ContextVar("db_state", default=db_state_default.copy())
 
 
-async def reset_db_state():
+def reset_db_state():
     """ Sub-depdency for get_db that resets the context connection state """
     pdb._state._state.set(db_state_default.copy())
     pdb._state.reset()
@@ -44,7 +45,11 @@ def connect_db(db, orm: str = 'peewee'):
     """ Connect to the peewee sdss5db database """
 
     from valis.main import settings
-    profset = db.set_profile(settings.db_server)
+
+    if db.connected:
+        return db
+
+    profset = db.set_profile(settings.db_server) if settings.db_server else None
     if settings.db_remote and not profset:
         port = settings.db_port
         user = settings.db_user
@@ -62,20 +67,27 @@ def connect_db(db, orm: str = 'peewee'):
 # local local dev
 # pdb.connect_from_parameters(dbname='sdss5db', host='localhost', port=6000, user='u0857802')
 
-def get_pw_db(db_state=Depends(reset_db_state)):
+def get_pw_db():
     """ Dependency to connect a database with peewee """
+
+    from valis.main import settings
+
+    if settings.db_reset:
+        reset_db_state()
 
     # connect to the db, yield None since we don't need the db in peewee
     db = connect_db(pdb, orm='peewee')
     try:
         yield db
     finally:
-        if db:
+        if db and settings.db_reset:
             db.close()
 
 
 def get_sqla_db():
     """ Dependency to connect to a database with sqlalchemy """
+
+    from valis.main import settings
 
     # connect to the db, yield the db Session object for sql queries
     db = connect_db(sdb, orm='sqla')
@@ -83,5 +95,5 @@ def get_sqla_db():
     try:
         yield db
     finally:
-        if db:
+        if db and settings.db_reset:
             db.close()

--- a/python/valis/settings.py
+++ b/python/valis/settings.py
@@ -33,12 +33,13 @@ class EnvEnum(str, Enum):
 class Settings(BaseSettings):
     valis_env: EnvEnum = EnvEnum.dev
     allow_origin: Union[str, List[AnyHttpUrl]] = Field([])
-    db_server: str = 'pipelines'
+    db_server: str | None = 'pipelines'
     db_remote: bool = False
     db_port: int = 5432
     db_user: Optional[str] = None
     db_host: Optional[str] = 'localhost'
     db_pass: Optional[str] = None
+    db_reset: bool = True
     model_config = SettingsConfigDict(env_prefix="valis_")
 
     @field_validator('allow_origin')
@@ -52,4 +53,3 @@ class Settings(BaseSettings):
     @classmethod
     def strip_slash(cls, v):
         return [i.rstrip('/') for i in v]
-


### PR DESCRIPTION
Adds some additional options to facilitate development without the DB connection having to be recreated for every query (which takes a long time with Peewee using a tunnel as the reconnection forces the models to be re-reflected).

- `sdssdb` does not try to connect to the default profile when the database is imported. In development this will fail but take a long time because `pipelines.sdss.org` is not reacheable. This should be ok since every query has `get_pw_db` as a dependency.

- If `db_server` is None, it does not try to connect to a profile and uses `db_user`, `db_host`, etc.

- If `db_reset` is `False`, it does not close the connection, and the next time the DB is required it does not try to reconnect.

For development one would edit `~/.config/sdss/valis.yaml` and add

```yaml
db_server: null
db_reset: false
db_user: ...
db_port: ...
...
```

Without a `valis.yaml` file or environment variables everything should behave as it did.