### PR TITLE
Updates search endpoints to use the new observed column

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,7 @@ Change Log
 * Adds endpoints for listing cartons and programs
 * Adds endpoints for target search by carton and program
 * Adds ``db_reset`` option to avoid closing and resetting the database connection
-* Updates main and cone search to use new ``has_been_observed`` column; default is True.
+* Updates main, cone, and carton/program search to use new ``has_been_observed`` column; default is True.
 * Updates the ``append_pipes`` query to return the new ``has_been_observed`` column
 
 0.1.0 (10-24-2023)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,8 @@ Change Log
 * Adds endpoints for listing cartons and programs
 * Adds endpoints for target search by carton and program
 * Adds ``db_reset`` option to avoid closing and resetting the database connection
+* Updates main and cone search to use new ``has_been_observed`` column; default is True.
+* Updates the ``append_pipes`` query to return the new ``has_been_observed`` column
 
 0.1.0 (10-24-2023)
 ------------------

--- a/python/valis/db/models.py
+++ b/python/valis/db/models.py
@@ -7,7 +7,7 @@
 import datetime
 import math
 from typing import Optional, Annotated, Any, TypeVar
-from pydantic import ConfigDict, BaseModel, Field, BeforeValidator
+from pydantic import ConfigDict, BaseModel, Field, BeforeValidator, field_validator, FieldValidationInfo
 from enum import Enum
 
 
@@ -76,7 +76,15 @@ class SDSSidPipesBase(PeeweeBase):
     in_boss: bool = Field(..., description='Flag if target is in the BHM reductions', examples=[False])
     in_apogee: bool = Field(..., description='Flag if target is in the MWM reductions', examples=[False])
     in_astra: bool = Field(..., description='Flag if the target is in the Astra reductions', examples=[False])
+    has_been_observed: Optional[bool] = Field(False, validate_default=True, description='Flag if target has been observed or not', examples=[False])
 
+    @field_validator('has_been_observed')
+    @classmethod
+    def is_observed(cls, v: str, info: FieldValidationInfo) -> str:
+        """ validator for when has_been_observed was not available in table """
+        if not v:
+            return info.data['in_boss'] or info.data['in_apogee'] or info.data['in_astra']
+        return v
 
 class SDSSModel(SDSSidStackedBase, SDSSidPipesBase):
     """ Main Pydantic response for SDSS id plus Pipes flags """

--- a/python/valis/db/queries.py
+++ b/python/valis/db/queries.py
@@ -275,7 +275,7 @@ def carton_program_search(name: str,
     """
 
     if query is None:
-        query = vizdb.SDSSidStacked.select(peewee.fn.DISTINCT(vizdb.SDSSidStacked.sdss_id))
+        query = vizdb.SDSSidStacked.select(vizdb.SDSSidStacked).distinct()
 
     query = (query.join(
                 vizdb.SDSSidFlat,

--- a/python/valis/routes/query.py
+++ b/python/valis/routes/query.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, Field, BeforeValidator
 
 from valis.routes.base import Base
 from valis.db.db import get_pw_db
-from valis.db.models import SDSSidStackedBase, SDSSidPipesBase, MapperName
+from valis.db.models import SDSSidStackedBase, SDSSidPipesBase, MapperName, SDSSModel
 from valis.db.queries import (cone_search, append_pipes, carton_program_search,
                               carton_program_list, carton_program_map,
                               get_targets_by_sdss_id, get_targets_by_catalog_id,
@@ -30,16 +30,16 @@ class SearchCoordUnits(str, Enum):
 
 class SearchModel(BaseModel):
     """ Input main query body model """
-    ra: Optional[Union[float, str]] = Field(None, description='Right Ascension in degrees or hmsdms', example=315.01417)
-    dec: Optional[Union[float, str]] = Field(None, description='Declination in degrees or hmsdms', example=35.299)
-    radius: Optional[Float] = Field(None, description='Search radius in specified units', example=0.01)
+    ra: Optional[Union[float, str]] = Field(None, description='Right Ascension in degrees or hmsdms', example=315.78)
+    dec: Optional[Union[float, str]] = Field(None, description='Declination in degrees or hmsdms', example=-3.2)
+    radius: Optional[Float] = Field(None, description='Search radius in specified units', example=0.02)
     units: Optional[SearchCoordUnits] = Field('degree', description='Units of search radius', example='degree')
     id: Optional[Union[int, str]] = Field(None, description='The SDSS identifier', example=23326)
     program: Optional[str] = Field(None, description='The program name', example='bhm_rm')
     carton: Optional[str] = Field(None, description='The carton name', example='bhm_rm_core')
+    observed: Optional[bool] = Field(True, description='Flag to only include targets that have been observed', example=True)
 
-
-class MainResponse(SDSSidPipesBase, SDSSidStackedBase):
+class MainResponse(SDSSModel):
     """ Combined model from all individual query models """
 
 
@@ -97,20 +97,23 @@ class QueryRoutes(Base):
                                           'program' if body.program else 'carton',
                                           query=query)
         # append query to pipes
-        query = append_pipes(query)
+        query = append_pipes(query, observed=body.observed)
 
         return {'status': 'success', 'data': query.dicts().iterator(), 'msg': 'data successfully retrieved'}
 
     @router.get('/cone', summary='Perform a cone search for SDSS targets with sdss_ids',
-                response_model=List[SDSSidStackedBase], dependencies=[Depends(get_pw_db)])
+                response_model=List[SDSSModel], dependencies=[Depends(get_pw_db)])
     async def cone_search(self,
-                          ra: Annotated[Union[float, str], Query(description='Right Ascension in degrees or hmsdms', example=315.01417)],
-                          dec: Annotated[Union[float, str], Query(description='Declination in degrees or hmsdms', example=35.299)],
-                          radius: Annotated[float, Query(description='Search radius in specified units', example=0.01)],
-                          units: Annotated[SearchCoordUnits, Query(description='Units of search radius', example='degree')] = "degree"):
+                          ra: Annotated[Union[float, str], Query(description='Right Ascension in degrees or hmsdms', example=315.78)],
+                          dec: Annotated[Union[float, str], Query(description='Declination in degrees or hmsdms', example=-3.2)],
+                          radius: Annotated[float, Query(description='Search radius in specified units', example=0.02)],
+                          units: Annotated[SearchCoordUnits, Query(description='Units of search radius', example='degree')] = "degree",
+                          observed: Annotated[bool, Query(description='Flag to only include targets that have been observed', example=True)] = True):
         """ Perform a cone search """
 
-        return list(cone_search(ra, dec, radius, units=units))
+        res = cone_search(ra, dec, radius, units=units)
+        r = append_pipes(res, observed=observed)
+        return r.dicts().iterator()
 
     @router.get('/sdssid', summary='Perform a search for an SDSS target based on the sdss_id',
                 response_model=Union[SDSSidStackedBase, dict], dependencies=[Depends(get_pw_db)])
@@ -135,7 +138,7 @@ class QueryRoutes(Base):
     async def sdss_ids_search(self, body: SDSSIdsModel):
         """ Perform a search for SDSS targets based on a list of input sdss_id values."""
         return list(get_targets_by_sdss_id(body.sdss_id_list))
-    
+
     @router.get('/catalogid', summary='Perform a search for SDSS targets based on the catalog_id',
                 response_model=List[SDSSidStackedBase], dependencies=[Depends(get_pw_db)])
     async def catalog_id_search(self, catalog_id: Annotated[int, Query(description='Value of catalog_id', example=7613823349)]):
@@ -173,7 +176,7 @@ class QueryRoutes(Base):
                                                         description='Specify search on carton or program',
                                                         example='carton')] = 'carton'):
         """ Perform a search on carton or program """
-        with database.atomic() as transaction:
+        with database.atomic():
             database.execute_sql('SET LOCAL enable_seqscan=false;')
             return list(carton_program_search(name, name_type))
 
@@ -195,7 +198,7 @@ class QueryRoutes(Base):
 
     @router.get('/mapper', summary='Perform a search for SDSS targets based on the mapper',
                 response_model=List[SDSSidStackedBase], dependencies=[Depends(get_pw_db)])
-    async def get_target_list_by_mapper(self, 
+    async def get_target_list_by_mapper(self,
                                         mapper: Annotated[MapperName, Query(description='Mapper name', example=MapperName.MWM)] = MapperName.MWM,
                                         page_number: Annotated[int, Query(description='Page number of the returned items', gt=0, example=1)] = 1,
                                         items_per_page: Annotated[int, Query(description='Number of items displayed in a page', gt=0, example=10)] = 10):


### PR DESCRIPTION
This PR closes #29.  It updates the `append_pipes` query to also return the new `has_been_observed` column, and allows for filtering results based on the new column.  The default is set to True, to always filter for only observed targets.  It updates the cone search (`/query/cone`) endpoint and the main search (`/query/main`) endpoint, to use the new observed column. 

Currently requires the latest main of `sdssdb` to use. 