### PR TITLE
Implement `/target/parents` endpoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Change Log
 * Adds ``db_reset`` option to avoid closing and resetting the database connection
 * Updates main, cone, and carton/program search to use new ``has_been_observed`` column; default is True.
 * Updates the ``append_pipes`` query to return the new ``has_been_observed`` column
+* Adds endpoint to get parent catalog data for a given target (#38).
 
 0.1.0 (10-24-2023)
 ------------------

--- a/poetry.lock
+++ b/poetry.lock
@@ -5754,13 +5754,13 @@ docs = ["Sphinx (>=7.2.0)", "importlib-metadata (>=1.6.0)", "jinja2 (<3.1)", "re
 
 [[package]]
 name = "sdssdb"
-version = "0.12.3"
+version = "0.12.4"
 description = "SDSS product for database management"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "sdssdb-0.12.3-py3-none-any.whl", hash = "sha256:67102b0075cbe79a399a791d3e7e018440429d5a7c3d4734b9bdc002a0e70998"},
-    {file = "sdssdb-0.12.3.tar.gz", hash = "sha256:743e9fdf81da22b700323417f235eb3d0145e4336e65c78b96cb0f9e6168c1b7"},
+    {file = "sdssdb-0.12.4-py3-none-any.whl", hash = "sha256:cba5393621d6a7a455954c8a0ca695f91846e109043435669545b01804b6bd11"},
+    {file = "sdssdb-0.12.4.tar.gz", hash = "sha256:ac4c1e021cc3454c1fed319cf6e646041af7378d322b0bb89f852366e6471e1a"},
 ]
 
 [package.dependencies]
@@ -7528,4 +7528,4 @@ solara = ["sdss-solara"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.10"
-content-hash = "5a6c6add56086dab357ab8112c067e2c46e1a000c0b96a075e738ea24e932159"
+content-hash = "392b8427145afc9c48e6c3ee2bf315d3699aaf00d7ab207d1d3f19bf938b1ba9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ httpx = "^0.24.0"
 astroquery = "^0.4.6"
 pandas = "^1.5.3"
 SQLAlchemy = "^1.4.35"
-sdssdb = "^0.12.3"
+sdssdb = "^0.12.4"
 deepmerge = "^1.1.1"
 fuzzy-types = "^0.1.3"
 sdss-solara = {git = "https://github.com/sdss/sdss_solara.git", rev = "main", optional = true}

--- a/python/valis/db/models.py
+++ b/python/valis/db/models.py
@@ -192,6 +192,16 @@ class CatalogModel(PeeweeBase):
     parallax: Optional[float] = None
 
 
+class ParentCatalogModel(PeeweeBase):
+    """Pydantic model for parent catalog information """
+
+    sdss_id: int
+    catalogid: int
+    catalog: str
+    field_name: str
+    parent_catalog_id: int | str
+
+
 class CatalogResponse(CatalogModel, SDSSidFlatBase):
     """ Response model for source catalog and sdss_id information """
     pass

--- a/python/valis/db/models.py
+++ b/python/valis/db/models.py
@@ -197,9 +197,10 @@ class ParentCatalogModel(PeeweeBase):
 
     sdss_id: int
     catalogid: int
-    catalog: str
-    field_name: str
-    parent_catalog_id: int | str
+
+    # This model is usually instantiated with a dictionary of all the parent
+    # catalogue columns so we allow extra fields.
+    model_config = ConfigDict(extra='allow')
 
 
 class CatalogResponse(CatalogModel, SDSSidFlatBase):

--- a/python/valis/db/models.py
+++ b/python/valis/db/models.py
@@ -195,8 +195,8 @@ class CatalogModel(PeeweeBase):
 class ParentCatalogModel(PeeweeBase):
     """Pydantic model for parent catalog information """
 
-    sdss_id: int
-    catalogid: int
+    sdss_id: Annotated[int, Field(description='The sdss_id associated with the parent catalogue data')]
+    catalogid: Annotated[int, Field(description='The catalogid associated with the parent catalogue data')]
 
     # This model is usually instantiated with a dictionary of all the parent
     # catalogue columns so we allow extra fields.

--- a/python/valis/db/queries.py
+++ b/python/valis/db/queries.py
@@ -707,9 +707,7 @@ def get_parent_catalog_data(sdss_id: int, catalog: str) -> peewee.ModelSelect:
 
     ParentModel = cat.database.models[fqtn]
 
-    return (SID.select(SID.sdss_id,
-                       SID.catalogid,
-                       ParentModel)
+    return (SID.select(SID.sdss_id, SID.catalogid, ParentModel)
                .join(ParentModel)
                .where(SID.sdss_id == sdss_id)
                .order_by(SID.catalogid))

--- a/python/valis/db/queries.py
+++ b/python/valis/db/queries.py
@@ -694,6 +694,33 @@ def get_catalog_sources(sdss_id: int) -> peewee.ModelSelect:
         join(s, on=(s.c.catalogid == cat.Catalog.catalogid)).order_by(cat.Catalog.version.desc())
 
 
+def get_parent_catalog_data(sdss_id: int, catalog: str) -> peewee.ModelSelect:
+    """Returns parent catalog data for a given target."""
+
+    SID = cat.SDSS_ID_To_Catalog
+
+    cat_field: peewee.Field | None = None
+    cat_pk_name: str | None = None
+    for field in SID._meta.fields.values():
+        if '__' not in field.name:
+            continue
+        if field.name.split('__')[0] == catalog:
+            cat_field = field
+            cat_pk_name = field.name.split('__')[1]
+            break
+
+    if cat_field is None or cat_pk_name is None:
+        raise ValueError(f'Catalog {catalog} not found in SDSS_ID_To_Catalog table.')
+
+    return (SID.select(SID.sdss_id,
+                       SID.catalogid,
+                       peewee.Value(catalog).alias('catalog'),
+                       peewee.Value(cat_pk_name).alias('field_name'),
+                       field.alias('parent_catalog_id'))
+               .where(SID.sdss_id == sdss_id)
+               .order_by(SID.catalogid))
+
+
 def get_target_cartons(sdss_id: int) -> peewee.ModelSelect:
     """ Get the carton info for a target sdss_id
 

--- a/python/valis/routes/target.py
+++ b/python/valis/routes/target.py
@@ -196,19 +196,19 @@ class Target(Base):
 
         return response_data
 
-    @router.get('/parents/{parent_catalog}/{sdss_id}',
+    @router.get('/parents/{catalog}/{sdss_id}',
                 dependencies=[Depends(get_pw_db)],
                 response_model=ParentCatalogModel,
                 summary='Retrieve parent catalog information for a taget by sdss_id')
     async def get_parents(self,
-                          parent_catalog: str = Path(title='The parent catalog to search',
-                                                     example='gaia_dr3_source'),
-                          sdss_id = Path(title='The sdss_id of the target to get',
-                                         example=129055990)):
+                          catalog: Annotated[str, Path(description='The parent catalog to search',
+                                                       example='gaia_dr3_source')],
+                          sdss_id: Annotated[int, Path(description='The sdss_id of the target to get',
+                                                       example=129055990)]):
         """Return parent catalog information for a given sdss_id """
 
         try:
-            result = get_parent_catalog_data(sdss_id, parent_catalog).dicts()
+            result = get_parent_catalog_data(sdss_id, catalog).dicts()
             if len(result) == 0:
                 raise ValueError(f'No parent catalog data found for sdss_id {sdss_id}')
         except Exception as e:

--- a/python/valis/routes/target.py
+++ b/python/valis/routes/target.py
@@ -199,6 +199,7 @@ class Target(Base):
     @router.get('/parents/{catalog}/{sdss_id}',
                 dependencies=[Depends(get_pw_db)],
                 response_model=ParentCatalogModel,
+                responses={400: {'description': 'Invalid input sdss_id or catalog'}},
                 summary='Retrieve parent catalog information for a taget by sdss_id')
     async def get_parents(self,
                           catalog: Annotated[str, Path(description='The parent catalog to search',
@@ -212,7 +213,7 @@ class Target(Base):
             if len(result) == 0:
                 raise ValueError(f'No parent catalog data found for sdss_id {sdss_id}')
         except Exception as e:
-            raise HTTPException(status_code=500, detail=f'Error: {e}')
+            raise HTTPException(status_code=400, detail=f'Error: {e}')
 
         return result[0]
 


### PR DESCRIPTION
Implements a new endpoint `/target/parents/{catalog}/{sdss_id}` which returns parent catalog information for a given sdss_id. The response model is

> ~{~ 
>  ~"sdss_id": 129055990,~
>  ~"catalogid": 63050395068163877,~
>  ~"catalog": "gaia_dr3_source",~
>  ~"field_name": "source_id",~
>  ~"parent_catalog_id": 2605275489003187072~
> ~}~

~I'm not sure about the route name or the response contents or field names.~

```console
>> curl -L "http://127.0.0.1:8000/target/parents/gaia_dr3_source/129055990"            
{"sdss_id":129055990,"catalogid":63050395068163877,"source_id":2605275489003187072,"solution_id":1636148068921376768,"designation":"Gaia DR3 2605275489003187072","random_index":1020005880,"ref_epoch":2016.0,"ra":342.8413714603454,"ra_error":0.842067,"dec":-10.239850309221548,"dec_error":0.9484852,"parallax":10.907291430285165,"parallax_error":1.0142229,"parallax_over_error":10.754334,"pm":46.691307,"pmra":-21.311661454841314,"pmra_error":1.2463797,"pmdec":-41.543848204958365,"pmdec_error":1.1763526,"ra_dec_corr":0.21672651,"ra_parallax_corr":0.09093504,"ra_pmra_corr":0.21584736,"ra_pmdec_corr":-0.0879561,"dec_parallax_corr":-0.33626717,"dec_pmra_corr":-0.04698392,"dec_pmdec_corr":0.14418805,"parallax_pmra_corr":-0.051337507,"parallax_pmdec_corr":-0.2278784,"pmra_pmdec_corr":0.124743745,"astrometric_n_obs_al":157,"astrometric_n_obs_ac":0,"astrometric_n_good_obs_al":152,"astrometric_n_bad_obs_al":5,"astrometric_gof_al":33.453407,"astrometric_chi2_al":2294.282,"astrometric_excess_noise":6.3394456,"astrometric_excess_noise_sig":59.842293,"astrometric_params_solved":95,"astrometric_primary_flag":false,"nu_eff_used_in_astrometry":null,"pseudocolour":0.85462797,"pseudocolour_error":0.21192579,"ra_pseudocolour_corr":-0.060202982,"dec_pseudocolour_corr":0.013923447,"parallax_pseudocolour_corr":0.051621795,"pmra_pseudocolour_corr":-0.004585662,"pmdec_pseudocolour_corr":-0.039514143,"astrometric_matched_transits":18,"visibility_periods_used":14,"astrometric_sigma5d_max":1.7950424,"matched_transits":20,"new_matched_transits":20,"matched_transits_removed":0,"ipd_gof_harmonic_amplitude":0.30820587,"ipd_gof_harmonic_phase":100.369415,"ipd_frac_multi_peak":31,"ipd_frac_odd_win":10,"ruwe":3.4963603,"scan_direction_strength_k1":0.28656563,"scan_direction_strength_k2":0.30943793,"scan_direction_strength_k3":0.43368298,"scan_direction_strength_k4":0.9103226,"scan_direction_mean_k1":-86.198715,"scan_direction_mean_k2":-51.241356,"scan_direction_mean_k3":-52.53388,"scan_direction_mean_k4":24.666033,"duplicated_source":false,"phot_g_n_obs":157,"phot_g_mean_flux":382.4679932200233,"phot_g_mean_flux_error":8.176602,"phot_g_mean_flux_over_error":46.775906,"phot_g_mean_mag":19.230879,"phot_bp_n_obs":11,"phot_bp_mean_flux":52.38008810924284,"phot_bp_mean_flux_error":11.834996,"phot_bp_mean_flux_over_error":4.425864,"phot_bp_mean_mag":21.040627,"phot_rp_n_obs":15,"phot_rp_mean_flux":711.6966545848484,"phot_rp_mean_flux_error":13.853812,"phot_rp_mean_flux_over_error":51.3719,"phot_rp_mean_mag":17.617159,"phot_bp_rp_excess_factor":1.9977534,"phot_bp_n_contaminated_transits":0,"phot_bp_n_blended_transits":0,"phot_rp_n_contaminated_transits":0,"phot_rp_n_blended_transits":0,"phot_proc_mode":0,"bp_rp":3.4234676,"bp_g":1.8097477,"g_rp":1.6137199,"radial_velocity":null,"radial_velocity_error":null,"rv_method_used":null,"rv_nb_transits":null,"rv_nb_deblended_transits":null,"rv_visibility_periods_used":null,"rv_expected_sig_to_noise":null,"rv_renormalised_gof":null,"rv_chisq_pvalue":null,"rv_time_duration":null,"rv_amplitude_robust":null,"rv_template_teff":null,"rv_template_logg":null,"rv_template_fe_h":null,"rv_atm_param_origin":null,"vbroad":null,"vbroad_error":null,"vbroad_nb_transits":null,"grvs_mag":null,"grvs_mag_error":null,"grvs_mag_nb_transits":null,"rvs_spec_sig_to_noise":null,"phot_variable_flag":"NOT_AVAILABLE","l":58.00400837113424,"b":-57.076535885991916,"ecl_lon":340.27793716202996,"ecl_lat":-2.7293360537442064,"in_qso_candidates":false,"in_galaxy_candidates":false,"non_single_star":0,"has_xp_continuous":false,"has_xp_sampled":false,"has_rvs":false,"has_epoch_photometry":false,"has_epoch_rv":false,"has_mcmc_gspphot":false,"has_mcmc_msc":false,"in_andromeda_survey":false,"classprob_dsc_combmod_quasar":1.02187715e-13,"classprob_dsc_combmod_galaxy":5.1042254e-13,"classprob_dsc_combmod_star":0.9999836,"teff_gspphot":null,"teff_gspphot_lower":null,"teff_gspphot_upper":null,"logg_gspphot":null,"logg_gspphot_lower":null,"logg_gspphot_upper":null,"mh_gspphot":null,"mh_gspphot_lower":null,"mh_gspphot_upper":null,"distance_gspphot":null,"distance_gspphot_lower":null,"distance_gspphot_upper":null,"azero_gspphot":null,"azero_gspphot_lower":null,"azero_gspphot_upper":null,"ag_gspphot":null,"ag_gspphot_lower":null,"ag_gspphot_upper":null,"ebpminrp_gspphot":null,"ebpminrp_gspphot_lower":null,"ebpminrp_gspphot_upper":null,"libname_gspphot":null}
```

Note that this PR also bumps `sdssdb` to 0.12.4 as there was a bug in the `SDSS_ID_To_Catalogs` that prevented querying or ordering by `catalogid`.

Closes #33.
