### PR TITLE
Add `/query/list/parents` endpoint

### DIFF
--- a/python/valis/routes/query.py
+++ b/python/valis/routes/query.py
@@ -15,7 +15,7 @@ from valis.db.queries import (cone_search, append_pipes, carton_program_search,
                               carton_program_list, carton_program_map,
                               get_targets_by_sdss_id, get_targets_by_catalog_id,
                               get_targets_obs, get_paged_target_list_by_mapper)
-from sdssdb.peewee.sdss5db import database
+from sdssdb.peewee.sdss5db import database, catalogdb
 
 # convert string floats to proper floats
 Float = Annotated[Union[float, str], BeforeValidator(lambda x: float(x) if x and isinstance(x, str) else x)]
@@ -171,6 +171,16 @@ class QueryRoutes(Base):
         """ Return a mapping of cartons in all programs """
 
         return carton_program_map()
+
+    @router.get('/list/parents', summary='Return a list of available parent catalog tables',
+                response_model=List[str])
+    async def parent_catalogs(self):
+        """Return a list of available parent catalog tables."""
+
+        columns = catalogdb.SDSS_ID_To_Catalog._meta.fields.keys()
+        catalogs = [col.split('__')[0] for col in columns if '__' in col]
+
+        return sorted(catalogs)
 
     @router.get('/carton-program', summary='Search for all SDSS targets within a carton or program',
                 response_model=List[SDSSModel], dependencies=[Depends(get_pw_db)])

--- a/python/valis/routes/query.py
+++ b/python/valis/routes/query.py
@@ -178,6 +178,9 @@ class QueryRoutes(Base):
         """Return a list of available parent catalog tables."""
 
         columns = catalogdb.SDSS_ID_To_Catalog._meta.fields.keys()
+
+        # In sdss_id_to_catalog table, the parent catalog columns are named
+        # as 'parent_catalog__parent_catalog_pk_column'.
         catalogs = [col.split('__')[0] for col in columns if '__' in col]
 
         return sorted(catalogs)


### PR DESCRIPTION
Adds a new `/query/list/parents` endpoint which returns the list of `catalogdb` tables that are referenced from `sdss_id_to_catalogs`.

```console
>> curl -L "http://127.0.0.1:8000/query/list/parents"                                                                              
["allstar_dr17_synspec_rev1","allwise","bhm_rm_v0","bhm_rm_v0_2","catwise","catwise2020","gaia_dr2_source","gaia_dr3_source","glimpse","guvcat","legacy_survey_dr10","legacy_survey_dr8","panstarrs1","ps1_g18","sdss_dr13_photoobj","skymapper_dr1_1","skymapper_dr2","supercosmos","tic_v8","twomass_psc","tycho2","unwise"]
```

Not sure about the `parents` segment of the route. I used `parents` to be symmetric with #38 but it could also be `catalogs`.

Closes #39.