### PR TITLE
Return all rows of parent data for a given sdss_id and catalogid

### DIFF
--- a/python/valis/db/queries.py
+++ b/python/valis/db/queries.py
@@ -696,7 +696,7 @@ def get_catalog_sources(sdss_id: int) -> peewee.ModelSelect:
         order_by(cat.Catalog.version.desc())
 
 
-def get_parent_catalog_data(sdss_id: int, catalog: str) -> peewee.ModelSelect:
+def get_parent_catalog_data(sdss_id: int, catalog: str, catalogid: int | None = None) -> peewee.ModelSelect:
     """Returns parent catalog data for a given target."""
 
     SID = cat.SDSS_ID_To_Catalog
@@ -707,9 +707,13 @@ def get_parent_catalog_data(sdss_id: int, catalog: str) -> peewee.ModelSelect:
 
     ParentModel = cat.database.models[fqtn]
 
+    cid_condition = (SID.catalogid == catalogid) if catalogid is not None else True
+
     return (SID.select(SID.sdss_id, SID.catalogid, ParentModel)
+               .distinct(SID.sdss_id, SID.catalogid)
                .join(ParentModel)
                .where(SID.sdss_id == sdss_id)
+               .where(cid_condition)
                .order_by(SID.catalogid))
 
 

--- a/python/valis/routes/target.py
+++ b/python/valis/routes/target.py
@@ -198,24 +198,31 @@ class Target(Base):
 
     @router.get('/parents/{catalog}/{sdss_id}',
                 dependencies=[Depends(get_pw_db)],
-                response_model=ParentCatalogModel,
+                response_model=list[ParentCatalogModel],
                 responses={400: {'description': 'Invalid input sdss_id or catalog'}},
                 summary='Retrieve parent catalog information for a taget by sdss_id')
     async def get_parents(self,
                           catalog: Annotated[str, Path(description='The parent catalog to search',
                                                        example='gaia_dr3_source')],
                           sdss_id: Annotated[int, Path(description='The sdss_id of the target to get',
-                                                       example=129055990)]):
-        """Return parent catalog information for a given sdss_id """
+                                                       example=129047350)],
+                          catalogid: Annotated[int, Query(description='Restrict the list of returned entries to this catalogid',
+                                                          example=63050396587194280)]=None):
+        """Return parent catalog information for a given sdss_is.
+
+        Returns a list of mappings for each set of parent catalogs associated
+        with the catalogid and sdss_id.
+
+        """
 
         try:
-            result = get_parent_catalog_data(sdss_id, catalog).dicts()
+            result = get_parent_catalog_data(sdss_id, catalog, catalogid=catalogid).dicts()
             if len(result) == 0:
                 raise ValueError(f'No parent catalog data found for sdss_id {sdss_id}')
         except Exception as e:
             raise HTTPException(status_code=400, detail=f'Error: {e}')
 
-        return result[0]
+        return result
 
     @router.get('/cartons/{sdss_id}', summary='Retrieve carton information for a target sdss_id',
                 dependencies=[Depends(get_pw_db)],


### PR DESCRIPTION
Change the `/target/parents/{catalog}/{sdss_id}` to return all the parent catalog entries for all the entries associated with `sdss_id` in `sdss_id_to_catalog`. This can be limited to one `catalogid` but passing a `?catalogid=` query parameter.

Note that in most cases this will return multiple rows for the same value, since generally the `sdss_id` will be associated with the same parent catalog value across different cross-matches. For example:

```console
curl -L "http://127.0.0.1:8000/target/parents/gaia_dr2_source/129047350"
```

returns three copies of the same entry in Gaia DR2 for `source_id=375250708536870400`.

That same sdss_id will only return one row for Gaia DR3, since only one of the catalogids associated with the sdss_id has Gaia DR3 information.

I also found that there are duplicates in the `sdss_id_to_catalog` view for the same catalogid and sdsdid. I'll investigate why those are being created and re-run the view, but for now I've added a `distinct` to the `get_parent_catalog_data` to reject them.

Fixes #42