### PR TITLE
Adds separation distance to output of cone searches

### DIFF
--- a/python/valis/db/queries.py
+++ b/python/valis/db/queries.py
@@ -156,7 +156,12 @@ def cone_search(ra: Union[str, float], dec: Union[str, float],
     radius *= u.Unit(units)
     radius = radius.to(u.degree).value
 
-    return vizdb.SDSSidStacked.select().\
+    # compute the separation in degrees
+    sep = peewee.fn.q3c_dist(ra, dec,
+                             vizdb.SDSSidStacked.ra_sdss_id,
+                             vizdb.SDSSidStacked.dec_sdss_id).alias('distance')
+
+    return vizdb.SDSSidStacked.select(vizdb.SDSSidStacked, sep).\
         where(vizdb.SDSSidStacked.cone_search(ra, dec, radius,
                                               ra_col='ra_sdss_id',
                                               dec_col='dec_sdss_id'))

--- a/python/valis/routes/info.py
+++ b/python/valis/routes/info.py
@@ -5,6 +5,7 @@
 from __future__ import print_function, division, absolute_import
 
 from collections import defaultdict
+import itertools
 from typing import List, Union, Dict, Annotated
 from fastapi import APIRouter, HTTPException, Depends, Query, Path
 from fastapi_restful.cbv import cbv
@@ -24,7 +25,7 @@ except ImportError:
     Phases = Surveys = Releases = Tags = ProductModel = SchemaModel = None
 
 from valis.db.db import get_pw_db
-from valis.db.models import DbMetadata
+from valis.db.models import DbMetadata, gen_misc_models
 from valis.db.queries import get_db_metadata
 from valis.routes.base import Base, release
 from valis.routes.auth import set_auth
@@ -44,9 +45,13 @@ def get_products(release: str = Depends(release), dm: SDSSDataModel = Depends(ge
 
 
 def convert_metadata(data) -> dict:
-    """ Convert db metadata output to a dict of dicts """
+    """ Convert db metadata output to a dict of dicts
+
+    Iterate over both db metadata output and any miscellanous
+    model parameters
+    """
     mm = defaultdict(dict)
-    for i in data:
+    for i in itertools.chain(data, gen_misc_models()):
         mm[i['schema']].update({i['column_name']: i})
     return mm
 

--- a/python/valis/routes/query.py
+++ b/python/valis/routes/query.py
@@ -77,7 +77,8 @@ class QueryRoutes(Base):
 
     @router.post('/main', summary='Main query for the UI or combining queries',
                  dependencies=[Depends(get_pw_db)],
-                 response_model=MainSearchResponse)
+                 response_model=MainSearchResponse, response_model_exclude_unset=True,
+                 response_model_exclude_none=True)
     async def main_search(self, body: SearchModel):
         """ Main query for UI and for combining queries together """
 
@@ -118,7 +119,9 @@ class QueryRoutes(Base):
 
         res = cone_search(ra, dec, radius, units=units)
         r = append_pipes(res, observed=observed)
-        return r.dicts().iterator()
+        # return sorted by distance
+        # doing this here due to the append_pipes distinct
+        return sorted(r.dicts().iterator(), key=lambda x: x['distance'])
 
     @router.get('/sdssid', summary='Perform a search for an SDSS target based on the sdss_id',
                 response_model=Union[SDSSidStackedBase, dict], dependencies=[Depends(get_pw_db)])


### PR DESCRIPTION
This PR closes #52.  The `cone_search` query now outputs the separation distance between the input target and the search results.  The new `distance` parameter is attached to the common `SDSSModel` response, and made optional since other non-cone-search endpoints use the same response.    

Since this is a new return parameter not originally in the pipelines database, we also include a hack to insert metadata for this parameter into the `/info/database` endpoint.  This way the front-end can take advantage of it automatically with no code changes.  