### PR TITLE
Bumps the sdss-solara git hash

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -5741,7 +5741,7 @@ test = ["pytest", "pytest-doctestplus"]
 type = "git"
 url = "https://github.com/sdss/sdss_solara.git"
 reference = "main"
-resolved_reference = "26dbaa67b2154aa541a643eb8e62fef65953ad50"
+resolved_reference = "22d46277cdd42a9426b984bbea4cca8f5a243c6e"
 
 [[package]]
 name = "sdss-tree"


### PR DESCRIPTION
This PR bumps the sdss-solara git commit to the latest to fold in changes from https://github.com/sdss/sdss_solara/pull/7, which addresses the smart y-scaling of Specviz.  