### PR TITLE
Adds sdssid lookup using alternative id

### DIFF
--- a/python/valis/routes/query.py
+++ b/python/valis/routes/query.py
@@ -14,7 +14,8 @@ from valis.db.models import SDSSidStackedBase, SDSSidPipesBase, MapperName, SDSS
 from valis.db.queries import (cone_search, append_pipes, carton_program_search,
                               carton_program_list, carton_program_map,
                               get_targets_by_sdss_id, get_targets_by_catalog_id,
-                              get_targets_obs, get_paged_target_list_by_mapper)
+                              get_targets_obs, get_paged_target_list_by_mapper,
+                              get_target_by_altid)
 from sdssdb.peewee.sdss5db import database, catalogdb
 
 # convert string floats to proper floats
@@ -35,6 +36,8 @@ class SearchModel(BaseModel):
     radius: Optional[Float] = Field(None, description='Search radius in specified units', example=0.02)
     units: Optional[SearchCoordUnits] = Field('degree', description='Units of search radius', example='degree')
     id: Optional[Union[int, str]] = Field(None, description='The SDSS identifier', example=23326)
+    altid: Optional[Union[int, str]] = Field(None, description='An alternative identifier', example=27021603187129892)
+    idtype: Optional[str] = Field(None, description='The type of integer id, for ambiguous ids', example="catalogid")
     program: Optional[str] = Field(None, description='The program name', example='bhm_rm')
     carton: Optional[str] = Field(None, description='The carton name', example='bhm_rm_core')
     observed: Optional[bool] = Field(True, description='Flag to only include targets that have been observed', example=True)
@@ -92,6 +95,10 @@ class QueryRoutes(Base):
         # build the id query
         elif body.id:
             query = get_targets_by_sdss_id(body.id)
+
+        # build the altid query
+        elif body.altid:
+            query = get_target_by_altid(body.altid, body.idtype)
 
         # build the program/carton query
         if body.program or body.carton:


### PR DESCRIPTION
This PR closes #53.  It adds a new endpoint `/target/sdssid/{id}` that allows to lookup a target sdss_id by an alternative id, like catalogid, the apogee id, or field-mjd-catalogid.    It returns the sdss id target info from the vizdb.sdss_id_stacked table, similar to the current main return query endpoint and the `target/id/{sdssid}` endpoint.   I minimally added just an sdssid lookup since I'm assuming users can follow-up with a query to the other sdssid-specific endpoints.  

It also updates the main query search form to accept an `altid` form field.  This is to support a future PR in zora to update the UI to add a new search field.  

It adds two new queries, `get_target_by_altid` and `get_sdssid_by_altid`.    The second performs the altid-to-sdssid lookup, using some clungy str/int parsing.   We could eventually replace this with a single `altid` database column somewhere that we could query directly.   

The current formats supported are:

     - a (e)BOSS plate-mjd-fiberid, e.g. "10235-58127-0020"
     - a BOSS field-mjd-catalogid, e.g. "101077-59845-27021603187129892"
     - an SDSS-IV APOGEE ID, e.g "2M23595980+1528407"
     - an SDSS-V catalogid, e.g. 2702160318712989
     - a GAIA DR3 ID, e.g. 4110508934728363520

@zachway1996 @albireox do y'all think this is sufficient to satisfy the issue?  Or do you think we need to add the altid has an option to all the other target and query endpoints that currently use sdssid?   Are there other altids we may want to support?
