### PR TITLE
adding release filter for queries using the mjd cutoffs

### DIFF
--- a/python/valis/routes/query.py
+++ b/python/valis/routes/query.py
@@ -107,7 +107,7 @@ class QueryRoutes(Base):
                                           query=query)
         # append query to pipes
         if query:
-            query = append_pipes(query, observed=body.observed)
+            query = append_pipes(query, observed=body.observed, release=self.release)
 
         # query iterator
         res = query.dicts().iterator() if query else []
@@ -125,7 +125,7 @@ class QueryRoutes(Base):
         """ Perform a cone search """
 
         res = cone_search(ra, dec, radius, units=units)
-        r = append_pipes(res, observed=observed)
+        r = append_pipes(res, observed=observed, release=self.release)
         # return sorted by distance
         # doing this here due to the append_pipes distinct
         return sorted(r.dicts().iterator(), key=lambda x: x['distance'])
@@ -208,7 +208,7 @@ class QueryRoutes(Base):
         with database.atomic():
             database.execute_sql('SET LOCAL enable_seqscan=false;')
             query = carton_program_search(name, name_type)
-            query = append_pipes(query, observed=observed)
+            query = append_pipes(query, observed=observed, release=self.release)
             return query.dicts().iterator()
 
     @router.get('/obs', summary='Return targets with spectrum at observatory',


### PR DESCRIPTION
This PR closes #49.  It adds a filter to the `append_pipes` method that filters down results based on the data release and the MJD cutoff for the given observatory.  

For releases less than DR17, we don't have a cutoff implemented yet, as these are different for different surveys.  See #71.  For all releases < DR17, it uses a MJD cutoff of 0 to effectively null the results, until we can properly support legacy data. 