### PR TITLE
Adds new endpoint for bulk query by altid

### DIFF
--- a/python/valis/db/queries.py
+++ b/python/valis/db/queries.py
@@ -1011,7 +1011,9 @@ def get_target_by_altid(id: str | int, idtype: str = None) -> peewee.ModelSelect
 def get_targets_by_altid(ids: list, idtype: str = None) -> peewee.ModelSelect:
     """ Get a list of targets by altid
 
-    _extended_summary_
+    Gets targets from a list of alternative identifier.  Iterates
+    to get the sdss_id for each id, then retrieves the list
+    of objects at once.
 
     Parameters
     ----------

--- a/python/valis/db/queries.py
+++ b/python/valis/db/queries.py
@@ -962,6 +962,9 @@ def get_sdssid_by_altid(id: str | int, idtype: str = None) -> peewee.ModelSelect
         elif idtype == 'gaiaid':
             # gaia dr3 id , e.g. 4110508934728363520
             field = 'gaia_dr3_source_id'
+        elif idtype == 'sdssid':
+            # sdss id, e.g. 23326
+            field = 'sdss_id'
         else:
             field = 'catalogid'
 
@@ -991,6 +994,10 @@ def get_target_by_altid(id: str | int, idtype: str = None) -> peewee.ModelSelect
     peewee.ModelSelect
         the ORM query
     """
+    # if idtype is explicitly sdss_id, return it directly
+    if idtype == 'sdssid':
+        return get_targets_by_sdss_id(id)
+
     # get the sdss_id
     targ = get_sdssid_by_altid(id, idtype=idtype)
     res = targ.get_or_none() if targ else None
@@ -999,6 +1006,27 @@ def get_target_by_altid(id: str | int, idtype: str = None) -> peewee.ModelSelect
 
     # get the sdss_id metadata info
     return get_targets_by_sdss_id(res.sdss_id)
+
+
+def get_targets_by_altid(ids: list, idtype: str = None) -> peewee.ModelSelect:
+    """ Get a list of targets by altid
+
+    _extended_summary_
+
+    Parameters
+    ----------
+    id : str | int
+        the input alternative id
+    idtype : str, optional
+        the type of integer id, by default None
+
+    Returns
+    -------
+    peewee.ModelSelect
+        the ORM query
+    """
+    res = (j.sdss_id for i in ids for j in get_sdssid_by_altid(i, idtype=idtype) if j)
+    return get_targets_by_sdss_id(list(res))
 
 
 def create_temporary_table(query: peewee.ModelSelect,

--- a/python/valis/routes/query.py
+++ b/python/valis/routes/query.py
@@ -67,6 +67,10 @@ class AltEnum(str, Enum):
     gaiaid = 'gaiaid'
     sdssid = 'sdssid'
     twomassid = 'twomassid'
+    specobjid = 'specobjid'
+    platefibermjd = 'platefibermjd'
+    photoobjid = 'photoobjid'
+    fieldmjdcatalogid = 'fieldmjdcatalogid'
 
 class AltIdsModel(BaseModel):
     """Request body for the endpoint returning targets from an altid list"""

--- a/python/valis/routes/query.py
+++ b/python/valis/routes/query.py
@@ -4,7 +4,7 @@
 
 from enum import Enum
 from typing import List, Union, Dict, Annotated, Optional
-from fastapi import APIRouter, Depends, Query, HTTPException
+from fastapi import APIRouter, Depends, Query, HTTPException, Body
 from fastapi_restful.cbv import cbv
 from pydantic import BaseModel, Field, BeforeValidator
 
@@ -16,7 +16,7 @@ from valis.db.queries import (cone_search, append_pipes, carton_program_search,
                               carton_program_list, carton_program_map,
                               get_targets_by_sdss_id, get_targets_by_catalog_id,
                               get_targets_obs, get_paged_target_list_by_mapper,
-                              get_target_by_altid)
+                              get_target_by_altid, get_targets_by_altid)
 from valis.routes.auth import set_auth
 from sdssdb.peewee.sdss5db import database, catalogdb
 
@@ -59,6 +59,19 @@ class MainSearchResponse(BaseModel):
 class SDSSIdsModel(BaseModel):
     """Request body for the endpoint returning targets from an sdss_id list"""
     sdss_id_list: List[int] = Field(description='List of sdss_id values', example=[67660076, 67151446])
+
+class AltEnum(str, Enum):
+    """ Enum for the alternative id types """
+    apogeeid = 'apogeeid'
+    catalogid = 'catalogid'
+    gaiaid = 'gaiaid'
+    sdssid = 'sdssid'
+    twomassid = 'twomassid'
+
+class AltIdsModel(BaseModel):
+    """Request body for the endpoint returning targets from an sdss_id list"""
+    altid_list: List[str|int] = Field(description='List of altid values', example=['2M10193634+1952122', '2M14030226+5112480'])
+    idtype: Optional[AltEnum] = Field(None, description='For ambiguous integer ids, the type of id, e.g. "catalogid"', example=['apogeeid'])
 
 
 router = APIRouter()
@@ -164,11 +177,19 @@ class QueryRoutes(Base):
         return targets or {}
 
     @router.post('/sdssid', summary='Perform a search for SDSS targets based on a list of sdss_id values',
-                response_model=List[SDSSidStackedBase],
+                response_model=List[SDSSModel],
                 dependencies=[Depends(get_pw_db), Depends(set_auth)])
     async def sdss_ids_search(self, body: SDSSIdsModel):
         """ Perform a search for SDSS targets based on a list of input sdss_id values."""
-        return list(get_targets_by_sdss_id(body.sdss_id_list))
+        return list(append_pipes(get_targets_by_sdss_id(body.sdss_id_list), release=self.release).dicts())
+        #return list(get_targets_by_sdss_id(body.sdss_id_list))
+
+    @router.post('/altids', summary='Performa search for SDSS targets based on a list of alternative ids',
+                response_model=List[SDSSModel],
+                dependencies=[Depends(get_pw_db), Depends(set_auth)])
+    async def altids_search(self, body: AltIdsModel):
+        """ Perform a search for SDSS targets based on a list of input altid values."""
+        return list(append_pipes(get_targets_by_altid(body.altid_list, idtype=body.idtype), release=self.release).dicts())
 
     @router.get('/catalogid', summary='Perform a search for SDSS targets based on the catalog_id',
                 response_model=List[SDSSidStackedBase],

--- a/python/valis/routes/query.py
+++ b/python/valis/routes/query.py
@@ -69,7 +69,7 @@ class AltEnum(str, Enum):
     twomassid = 'twomassid'
 
 class AltIdsModel(BaseModel):
-    """Request body for the endpoint returning targets from an sdss_id list"""
+    """Request body for the endpoint returning targets from an altid list"""
     altid_list: List[str|int] = Field(description='List of altid values', example=['2M10193634+1952122', '2M14030226+5112480'])
     idtype: Optional[AltEnum] = Field(None, description='For ambiguous integer ids, the type of id, e.g. "catalogid"', example=['apogeeid'])
 

--- a/python/valis/routes/target.py
+++ b/python/valis/routes/target.py
@@ -178,7 +178,10 @@ class Target(Base):
         idtype: Annotated[str, Query(enum=['catalogid', 'gaiaid'], description='For ambiguous integer ids, the type of id, e.g. "catalogid"', example=None)] = None
         ):
         """ Return target metadata for a given sdss_id """
-        query = append_pipes(get_target_by_altid(id, idtype=idtype), observed=False)
+        query = get_target_by_altid(id, idtype=idtype)
+        if not query:
+            return {}
+        query = append_pipes(query, observed=False)
         return query.dicts().first() or {}
 
     @router.get('/spectra/{sdss_id}', summary='Retrieve a spectrum for a target sdss_id',

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -37,8 +37,3 @@ def test_build_file_path():
     path = build_file_path(astra_res, 'mwmStar', 'IPL3', defaults={'component': ''}, ignore_existence=True)
     assert 'sas/ipl-3/spectro/astra/0.5.0/spectra' in path
     assert '25/44/mwmStar-0.5.0-54392544.fits' in path
-
-def test_build_fails():
-    """ test build filepath fails correctly """
-    with pytest.raises(ValueError, match="Not all path keywords found in model fields or tags: ['component']*"):
-        build_file_path(astra_res, 'mwmStar', 'IPL3', ignore_existence=True)


### PR DESCRIPTION
This PR adds a new API endpoint, `/query/altids` to search for targets by alternative id in bulk.  It adds a post request, similar to `/query/sdssid` that accepts a list of ids.  This is similar to `/target/sdssid/{id}/` to get a target by an alternative id.  

The post body accepts `alt_id_list` as a list of identifier names or ids, and `idtype` as a string indicating the type of integer id.  For integer ids, can specify `sdssid`, `catalogid`, or `gaiaid` (DR3).  

Effectively closes #59.  The file upload handling is now done by the zora front-end. 