### PR TITLE
Updates the default release to DR19 

### DIFF
--- a/python/valis/routes/access.py
+++ b/python/valis/routes/access.py
@@ -104,12 +104,12 @@ class PathModel(PathResponse):
 class PathBody(BaseBody):
     """ Body for SDSS access paths post requests """
     kwargs: dict = Field({}, description='The keyword variable arguments defining a path',
-                         examples=[{"run2d": "v5_13_2", "plateid": 3606, "mjd": 55182, "fiberid": 22}])
+                         examples=[{"run2d": "v6_1_3", "fieldid": 112360, "mjd": 60052, "catalogid": 27021598150202075}])
     part: PathPart = Field('full', description='The part of the path to return')
     exists: bool = Field(False, description='Flag to check if the path exists')
 
 
-async def valid_name(name: str = FPath(description='the sdss access path name', example='spec-lite'),
+async def valid_name(name: str = FPath(description='the sdss access path name', example='specLite'),
                      access: Path = Depends(get_access)):
     """ Dependency to validate a path name """
     try:
@@ -122,10 +122,14 @@ async def valid_name(name: str = FPath(description='the sdss access path name', 
 
 key_constr = Annotated[str, StringConstraints(pattern="(?:,|^)((\w+)=(?:([\w\d.]+)))")]
 
+#/Users/brian/Work/sdss/sas/ipl-3/spectro/boss/redux/v6_1_3/spectra/lite/112360/60052/spec-112360-60052-27021598150202075.fits
+# examples
+# DR17 - spec-lite; ["plateid=3606", "mjd=55182", "fiberid=22", "run2d=v5_13_2"]
+# DR19 - specLite; ["fieldid=112360", "mjd=60052", "catalogid=27021598150202075", "run2d=v6_1_3"]
 
 async def extract_path(name: str = Depends(valid_name),
                        kwargs: List[key_constr] = Query(None, description='the keyword variable arguments defining a path',
-                                                        example=["plateid=3606", "mjd=55182", "fiberid=22", "run2d=v5_13_2"]),
+                                                        example=["fieldid=112360", "mjd=60052", "catalogid=27021598150202075", "run2d=v6_1_3"]),
                        access: Path = Depends(get_access)) -> Type[PathModel]:
     """ Dependency to extract and parse path name and keyword arguments """
 
@@ -219,7 +223,7 @@ class Paths(Base):
     @router.post("/{name}", summary='Get the template or resolved path for an sdss_access path name.',
                  response_model=PathResponse, response_model_exclude_unset=True)
     async def post_path_name(self, name: str = FPath(description='the sdss access path name',
-                                                     example='spec-lite'),
+                                                     example='specLite'),
                              body: PathBody = None):
         """ Construct an sdss_access path
 

--- a/python/valis/routes/base.py
+++ b/python/valis/routes/base.py
@@ -17,14 +17,14 @@ def validate_release(value: str) -> str:
 
 
 class BaseBody(BaseModel):
-    release: Optional[str] = Field(None, example='DR17', description='The SDSS data release')
+    release: Optional[str] = Field(None, example='DR19', description='The SDSS data release')
 
 
-async def release(release: str = Query(None, example='DR17', description='The SDSS data release'),
+async def release(release: str = Query(None, example='DR19', description='The SDSS data release'),
                   body: BaseBody = None) -> str:
     """ Dependency to specify a release query or body parameter """
     try:
-        final = validate_release(release or (body.release if body else None) or 'DR17')
+        final = validate_release(release or (body.release if body else None) or 'DR19')
     except ValueError as ee:
         raise HTTPException(status_code=422, detail=f'Validation Error: {ee}') from ee
     return final

--- a/python/valis/routes/envs.py
+++ b/python/valis/routes/envs.py
@@ -40,7 +40,7 @@ class Envs(Base):
     @router.get("/resolve", summary='Resolve the SDSS tree environment variables into their paths',
                 response_model=Union[Dict[str, dict], Dict[str, str]])
     async def resolve_envs(self, name: str = Query(None, descripion='the SDSS environment variable',
-                                                   example='MANGA_SPECTRO_REDUX')) -> dict:
+                                                   example='BOSS_SPECTRO_REDUX')) -> dict:
         """ Resolve an SDSS tree environment variable into its path """
         env = copy.deepcopy(self.tree.environ)
         env.pop('default')

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -2,12 +2,22 @@
 #
 
 
-def test_envs_default_dr17(client):
+def test_envs_default(client):
     response = client.get("/envs")
     assert response.status_code == 200
     data = response.json()
 
-    assert 'BHM' not in data['envs']
+    assert 'DATA' in data['envs']
+    assert 'MOS' in data['envs']
+    assert 'SPECTRO' in data['envs']
+    assert 'MANGA' not in data['envs']
+
+def test_envs_dr17(client):
+    response = client.get("/envs?release=DR17")
+    assert response.status_code == 200
+    data = response.json()
+
+    assert 'MOS' not in data['envs']
     assert 'MANGA' in data['envs']
     assert 'APOGEE_THEJOKER' in data['envs']['APOGEE']
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -8,11 +8,10 @@ from pytest import mark
 def test_main(client):
     response = client.get("/")
     assert response.status_code == 200
-    assert response.json() == {"Hello SDSS": "This is the FastAPI World", 'release': "DR17"}
+    assert response.json() == {"Hello SDSS": "This is the FastAPI World", 'release': "DR19"}
 
 @mark.parametrize('release', ['WORK', 'DR17'])
 def test_main_with_release(client, release):
     response = client.get("/", params={"release": release})
     assert response.status_code == 200
     assert response.json() == {"Hello SDSS": "This is the FastAPI World", 'release': release}
-


### PR DESCRIPTION
This PR updates the default release to DR19 and updates some of the examples from dr17 ones to newest ones.  

To do for a later time is to set up multiple examples in FastAPI to we can show older dr examples.  