### PR TITLE
Adds new route for legacy data lookup

### DIFF
--- a/python/valis/cache.py
+++ b/python/valis/cache.py
@@ -13,6 +13,7 @@
 from __future__ import annotations
 
 import base64
+import decimal
 import hashlib
 import json
 import logging
@@ -77,6 +78,9 @@ def bdefault(obj):
     # handle python memoryview objects
     if isinstance(obj, memoryview):
         return base64.b64encode(obj.tobytes()).decode()
+    elif isinstance(obj, decimal.Decimal):
+        # same as default pydantic
+        return str(obj)
     raise TypeError
 
 

--- a/python/valis/db/models.py
+++ b/python/valis/db/models.py
@@ -413,3 +413,9 @@ class AllSpecModel(PeeweeBase):
     def filepath(self) -> str:
         """ The legacy SAS filepath for the SDSS object """
         return build_legacy_path(self.__dict__, release=self.release, ignore_existence=True)
+
+    @computed_field(description='The marvin URL identifier for the SDSS MaNGA target')
+    @property
+    def marvin_url(self) -> str:
+        """ The marvin URL identifier for the SDSS object """
+        return f"https://magrathea.sdss.org/marvin/galaxy/{self.plateifu}/" if self.plateifu else None

--- a/python/valis/db/queries.py
+++ b/python/valis/db/queries.py
@@ -923,11 +923,15 @@ def get_sdssid_by_altid(id: str | int, idtype: str = None) -> peewee.ModelSelect
      - a (e)BOSS plate-mjd-fiberid, e.g. "10235-58127-0020"
      - a BOSS field-mjd-catalogid, e.g. "101077-59845-27021603187129892"
      - an SDSS-IV APOGEE ID, e.g "2M23595980+1528407"
+     - a MaNGA plate-ifu, e.g. "8485-1901"
+     - an SDSS specobjid, e.g. 3259575414686771200
      - an SDSS-V catalogid, e.g. 2702160318712989
      - a GAIA DR3 ID, e.g. 4110508934728363520
 
-     It queries either the boss_drp.boss_spectrum or astra.source
-     tables for the sdss_id.
+     It queries either the boss_drp.boss_spectrum, astra.source,
+     or vizb.allspec tables for the sdss_id.  For pure integer ids,
+     use the ``idtype`` parameter to specify the type of id
+     (e.g. 'specobjid', 'catalogid', 'gaiaid', 'sdssid').
 
     Parameters
     ----------

--- a/python/valis/db/queries.py
+++ b/python/valis/db/queries.py
@@ -977,6 +977,9 @@ def get_sdssid_by_altid(id: str | int, idtype: str = None) -> peewee.ModelSelect
         # apogee obj id
         targ = astra.Source.select(astra.Source.sdss_id).\
             where(astra.Source.sdss4_apogee_id.in_([id]))
+    elif ndash == 0 and idtype == 'specobjid':
+        # specobjid
+        targ = vizdb.AllSpec.select(vizdb.AllSpec.sdss_id).where(vizdb.AllSpec.specobjid.in_([id]))
     elif ndash == 0 and id.isdigit():
         # single integer id
         if idtype == 'catalogid':

--- a/python/valis/routes/query.py
+++ b/python/valis/routes/query.py
@@ -11,12 +11,12 @@ from pydantic import BaseModel, Field, BeforeValidator
 from valis.cache import valis_cache
 from valis.routes.base import Base
 from valis.db.db import get_pw_db
-from valis.db.models import SDSSidStackedBase, SDSSidPipesBase, MapperName, SDSSModel
+from valis.db.models import SDSSidStackedBase, SDSSidPipesBase, SDSSModel
 from valis.db.queries import (cone_search, append_pipes, carton_program_search,
                               carton_program_list, carton_program_map,
                               get_targets_by_sdss_id, get_targets_by_catalog_id,
                               get_targets_obs, get_paged_target_list_by_mapper,
-                              get_target_by_altid, get_targets_by_altid)
+                              get_target_by_altid, get_targets_by_altid, MapperName)
 from valis.routes.auth import set_auth
 from sdssdb.peewee.sdss5db import database, catalogdb
 

--- a/python/valis/routes/target.py
+++ b/python/valis/routes/target.py
@@ -175,9 +175,13 @@ class Target(Base):
                 response_model_exclude_unset=True, response_model_exclude_none=True)
     async def get_target_altid(self,
         id: Annotated[int | str, Path(title="The alternative id of the target to get", example="2M23595980+1528407")],
-        idtype: Annotated[str, Query(enum=['catalogid', 'gaiaid'], description='For ambiguous integer ids, the type of id, e.g. "catalogid"', example=None)] = None
+        idtype: Annotated[str, Query(enum=['catalogid', 'gaiaid', 'specobjid'], description='For ambiguous integer ids, the type of id, e.g. "catalogid"', example=None)] = None
         ):
-        """ Return target metadata for a given sdss_id """
+        """ Lookup an sdss_id for a given alternative id.
+
+        Alternative ids can be string ids: plate-mjd-fiberid, field-mjd-catalogid, apogee-id, mangaid, plate-ifu,
+        or integer ids: catalogid, gaiaid, specobjid. For pure integer ids, use the idtype field to specify the type of id
+        """
         query = get_target_by_altid(id, idtype=idtype)
         if not query:
             return {}

--- a/python/valis/utils/paths.py
+++ b/python/valis/utils/paths.py
@@ -181,3 +181,41 @@ def build_astra_path(values: dict, release: str, name: str = 'mwmStar',
     """
     return build_file_path(values, name, release, defaults={'component': ''},
                            ignore_existence=ignore_existence)
+
+
+def build_legacy_path(values: dict, release: str = "DR17", ignore_existence: bool = False) -> str:
+    """ Build a legacy SDSS file path
+
+    Builds a legacy SDSS file path using values from the allspec database table. It remaps various
+    column names to match their path template counterparts, and handles some default keywords.
+    It uses the sas_file to get the apogee N/S prefix, and translates the legacy spec file species name
+    back to its original name.
+
+    Parameters
+    ----------
+    values : dict
+        the input data values to give to the path template
+    release : str, optional
+        the data release, by default "DR17"
+    ignore_existence : bool, optional
+        flag to ignore file existence and return path, by default False
+
+    Returns
+    -------
+    str
+        the output file path
+    """
+    # translate this until we can set up some kind of aliasing
+    if release == 'DR17' and values['file_spec'] in ("specLite", "specFull"):
+        name = 'spec-lite' if values['file_spec'] == 'specLite' else 'spec'
+    else:
+        name = values['file_spec']
+
+    # set prefix for apogee files based on sas_file
+    # manga file have a sas_url but no sas_file???
+    prefix = values['sas_file'][0:2] if values.get('sas_file') else ""
+
+    return build_file_path(values, name, release=release,
+                           remap={'field':'apogee_field', 'apred':'apred_vers', 'obj':'apogee_id', 'ifu':'ifudsgn',
+                                  'plateid':'plate', 'fiber': 'fiberid', 'fieldid': 'fps_field'},
+                           defaults={'prefix': prefix, 'apstar':'stars', 'wave':'LOG'}, ignore_existence=ignore_existence)


### PR DESCRIPTION
This PR adds support looking up any legacy sdss spectra available for a given target sdss_id.  Adds a new `target/legacy` endpoint that accepts an sdss_id value that queries the allspec table and returns all matching rows.  By default, "legacy" is any sdss_phase < 5, but this is an optional input.  Setting `phase=0` will return all rows from the allspec table. 

Also adds a new AllSpec pydantic response model.  And adds new `build_legacy_path` wrapper function for returning a filepath on disk for legacy data, using the values from an allspec data row as input.  