### PR TITLE
Adds support for retrieving astra pipeline parameters

### DIFF
--- a/python/valis/cache.py
+++ b/python/valis/cache.py
@@ -78,6 +78,8 @@ def bdefault(obj):
     # handle python memoryview objects
     if isinstance(obj, memoryview):
         return base64.b64encode(obj.tobytes()).decode()
+    elif isinstance(obj, bytes):
+        return base64.b64encode(obj).decode()
     elif isinstance(obj, decimal.Decimal):
         # same as default pydantic
         return str(obj)

--- a/python/valis/db/models.py
+++ b/python/valis/db/models.py
@@ -423,12 +423,12 @@ class AllSpecModel(PeeweeBase):
 
 
 class AstraPipeline(PeeweeBase):
-    """Pydantic model for parent catalog information """
+    """Pydantic model for astra pipeline parameters """
 
     task_pk: Annotated[int | None, Field(strict=False, description='The task pk for the pipeline')] = None
     source: Annotated[int, Field(description='The source pk associated with the astra pipeline')]
     spectrum: Annotated[int, Field(description='The spectrum pk associated with the astra pipeline')]
 
-    # This model is usually instantiated with a dictionary of all the parent
-    # catalogue columns so we allow extra fields.
+    # This model may be instantiated from query results that include
+    # additional Astra pipeline or joined columns so we allow extra fields.
     model_config = ConfigDict(extra='allow')

--- a/python/valis/db/models.py
+++ b/python/valis/db/models.py
@@ -296,6 +296,7 @@ class PipesModel(PeeweeBase):
     apogee: Optional[ApogeeStar] = None
     astra: Optional[AstraSource] = None
     files: Optional[PipeFiles] = None
+    astra_pipelines: Optional[list[str]] = None
 
 
 class DbMetadata(PeeweeBase):
@@ -419,3 +420,15 @@ class AllSpecModel(PeeweeBase):
     def marvin_url(self) -> str:
         """ The marvin URL identifier for the SDSS object """
         return f"https://magrathea.sdss.org/marvin/galaxy/{self.plateifu}/" if self.plateifu else None
+
+
+class AstraPipeline(PeeweeBase):
+    """Pydantic model for parent catalog information """
+
+    task_pk: Annotated[int, Field(description='The task pk for the pipeline')]
+    source: Annotated[int, Field(description='The source pk associated with the astra pipeline')]
+    spectrum: Annotated[int, Field(description='The spectrum pk associated with the astra pipeline')]
+
+    # This model is usually instantiated with a dictionary of all the parent
+    # catalogue columns so we allow extra fields.
+    model_config = ConfigDict(extra='allow')

--- a/python/valis/db/models.py
+++ b/python/valis/db/models.py
@@ -425,7 +425,7 @@ class AllSpecModel(PeeweeBase):
 class AstraPipeline(PeeweeBase):
     """Pydantic model for parent catalog information """
 
-    task_pk: Annotated[int, Field(description='The task pk for the pipeline')]
+    task_pk: Annotated[int | None, Field(strict=False, description='The task pk for the pipeline')] = None
     source: Annotated[int, Field(description='The source pk associated with the astra pipeline')]
     spectrum: Annotated[int, Field(description='The spectrum pk associated with the astra pipeline')]
 

--- a/python/valis/db/queries.py
+++ b/python/valis/db/queries.py
@@ -4,6 +4,7 @@
 
 # all resuable queries go here
 
+import inspect
 import itertools
 import packaging
 import uuid
@@ -505,6 +506,17 @@ def get_apogee_target(sdss_id: int, release: str, fields: list = None) -> peewee
     # get the apogee star data
     return apo.Star.select(*fields).where(apo.Star.sdss_id == sdss_id, vercond)
 
+
+def check_astra_release(release: str) -> str | None:
+    """Check the astra tag release"""
+    vastra = get_software_tag(release, 'v_astra')
+    vcheck = "0.5.0" if vastra in ("0.5.0", "0.6.0") else vastra
+    if vcheck is None or vcheck.replace('.', '') not in astra.Source._meta.schema:
+        print(f"warning: astra version for current release {release} does not match assigned astra schema {astra.Source._meta.schema}")
+        return None
+    return vastra
+
+
 def get_astra_target(sdss_id: int, release: str, fields: list = None) -> peewee.ModelSelect:
     """Get the Astra target metadata for an sdss_id
 
@@ -526,10 +538,7 @@ def get_astra_target(sdss_id: int, release: str, fields: list = None) -> peewee.
         the output query
     """
     # check the astra version against the assigned schema
-    vastra = get_software_tag(release, 'v_astra')
-    vastra = "0.5.0" if vastra in ("0.5.0", "0.6.0") else vastra
-    if vastra is None or vastra.replace('.', '') not in astra.Source._meta.schema:
-        print(f"warning: astra version for current release {release} does not match assigned astra schema {astra.Source._meta.schema}")
+    if check_astra_release(release) is None:
         return None
 
     # check fields
@@ -631,7 +640,8 @@ def get_target_pipeline(sdss_id: int, release: str, pipeline: str = 'all') -> di
     # create initial dict
     data = {'info': {},
             'boss': {}, 'apogee': {}, 'astra': {},
-            'files': {'boss': '', 'apogee': '', 'astra': ['']}}
+            'files': {'boss': '', 'apogee': '', 'astra': ['']},
+            'astra_pipelines': []}
     data['info'].update(pipes or {})
 
     # if there is no match from vizdb, return nothing
@@ -662,6 +672,9 @@ def get_target_pipeline(sdss_id: int, release: str, pipeline: str = 'all') -> di
                 v = s.first().apogee_visit_spectrum.where(astra.ApogeeVisitSpectrum.apred == 'dr17').dicts().first()
                 path = build_apogee_path(v, 'DR17')
                 deepmerge.always_merger.merge(data, {'files': {'apogee': path}})
+
+    # get any astra pipelines the target is in
+    data['astra_pipelines'] = list_astra_pipelines(sdss_id, release)
 
     return data
 
@@ -1198,3 +1211,107 @@ def has_legacy_data(sdss_id: int, phase: int = 5) -> bool:
     in_allspec = get_legacy_allspec(sdss_id, phase).count()
     has_legcats = get_legacy_catalogs(sdss_id)
     return in_allspec > 0 or has_legcats != {}
+
+
+def list_astra_pipelines(sdss_id: int, release: str) -> list:
+    """ List the astra pipelines available for a given target
+
+    Lists the astra pipelines available for a given target sdss_id and data release.
+
+    Parameters
+    ----------
+    sdss_id : int
+        the input sdss_id
+    release : str
+        the SDSS data release
+
+    Returns
+    -------
+    list
+        the list of available astra pipelines for the target
+    """
+    # check the astra version against the assigned schema
+    if (vastra := check_astra_release(release)) is None:
+        return None
+
+    # drp pipeline versions
+    vers = (get_software_tag(release, 'run2d'), get_software_tag(release, 'apred_vers'))
+
+    ss = (vizdb.SDSSidToAstraPipeline.select(vizdb.SDSSidToAstraPipeline.pipeline_name).
+          where(vizdb.SDSSidToAstraPipeline.v_astra==vastra,
+               vizdb.SDSSidToAstraPipeline.sdss_id==sdss_id,
+               vizdb.SDSSidToAstraPipeline.drp_version.in_(vers))
+               .distinct().scalars())
+
+    return list(ss)
+
+
+def get_astra_pipeline(sdss_id: int, release: str, pipeline: str) -> peewee.ModelSelect:
+    """ Get the Astra pipeline data for a given target and pipeline name
+
+    Retrieves the astra pipeline data from the astra.source table
+    for a given target sdss_id, data release, and astra pipeline name.
+
+    Parameters
+    ----------
+    sdss_id : int
+        the input sdss_id
+    release : str
+        the SDSS data release
+    pipeline : str
+        the name of the astra pipeline
+
+    Returns
+    -------
+    peewee.ModelSelect
+        the output query
+    """
+    # check the astra version against the assigned schema
+    if (vastra := check_astra_release(release)) is None:
+        return None
+
+    tables = {v._meta.table_name: v for v in astra.__dict__.values() if inspect.isclass(v) and issubclass(v, astra.AstraBase)}
+
+    if pipeline not in tables:
+        raise ValueError(f"Astra pipeline {pipeline} not found in astra schema {vastra}.")
+
+    # drp pipeline versions
+    vers = (get_software_tag(release, 'run2d'), get_software_tag(release, 'apred_vers'))
+
+    # lookup the pipeline for the target sdss_id
+    pipes = list(vizdb.SDSSidToAstraPipeline.select().
+                 where(vizdb.SDSSidToAstraPipeline.v_astra==vastra,
+                       vizdb.SDSSidToAstraPipeline.sdss_id==sdss_id,
+                       vizdb.SDSSidToAstraPipeline.pipeline_name==pipeline,
+                       vizdb.SDSSidToAstraPipeline.drp_version.in_(vers)))
+
+    # no pipelines
+    if not pipes:
+        return None
+
+    # if more than one result, then likely different runs in pipeline tables, try to select the relevant one
+    # based on the latest pipeline tag for the given release.
+    if len(pipes) > 1:
+        specpks = [p.spectrum_pk for p in pipes]
+        if pipeline == 'boss_net':
+            version = get_software_tag(release, 'run2d')
+            res = astra.BossVisitSpectrum.select().where(astra.BossVisitSpectrum.spectrum.in_(specpks),
+                                                         astra.BossVisitSpectrum.run2d==version).get_or_none()
+        else:
+            version = get_software_tag(release, 'apred_vers')
+            res = astra.ApogeeVisitSpectrum.select().where(astra.ApogeeVisitSpectrum.spectrum.in_(specpks),
+                                                           astra.ApogeeVisitSpectrum.apred==version).get_or_none()
+        # select the matching pipe result
+        if res:
+            pipe = [p for p in pipes if p.source_pk == res.source.pk and p.spectrum_pk == res.spectrum.pk]
+
+    # query the astra pipeline table
+    pipe = pipes[0]
+    model = tables[pipeline]
+    query = model.select().where(model.source==pipe.source_pk,
+                                 model.spectrum==pipe.spectrum_pk)
+    res = list(query.dicts())
+
+    # return the most recent pipeline data if there are multiple entries
+    # or None if none found
+    return max(res, key=lambda i: i['created']) if res else None

--- a/python/valis/db/queries.py
+++ b/python/valis/db/queries.py
@@ -1232,10 +1232,11 @@ def list_astra_pipelines(sdss_id: int, release: str) -> list:
     """
     # check the astra version against the assigned schema
     if (vastra := check_astra_release(release)) is None:
-        return None
+        return []
 
-    # drp pipeline versions
+    # drp pipeline versions, flatten if multi-listed
     vers = (get_software_tag(release, 'run2d'), get_software_tag(release, 'apred_vers'))
+    vers = [i for v in vers for i in (v if isinstance(v, list) else [v])]
 
     ss = (vizdb.SDSSidToAstraPipeline.select(vizdb.SDSSidToAstraPipeline.pipeline_name).
           where(vizdb.SDSSidToAstraPipeline.v_astra==vastra,
@@ -1246,7 +1247,7 @@ def list_astra_pipelines(sdss_id: int, release: str) -> list:
     return list(ss)
 
 
-def get_astra_pipeline(sdss_id: int, release: str, pipeline: str) -> peewee.ModelSelect:
+def get_astra_pipeline(sdss_id: int, release: str, pipeline: str) -> dict:
     """ Get the Astra pipeline data for a given target and pipeline name
 
     Retrieves the astra pipeline data from the astra.source table
@@ -1276,8 +1277,9 @@ def get_astra_pipeline(sdss_id: int, release: str, pipeline: str) -> peewee.Mode
     if pipeline not in tables:
         raise ValueError(f"Astra pipeline {pipeline} not found in astra schema {vastra}.")
 
-    # drp pipeline versions
+    # drp pipeline versions, flatten if multi-listed
     vers = (get_software_tag(release, 'run2d'), get_software_tag(release, 'apred_vers'))
+    vers = [i for v in vers for i in (v if isinstance(v, list) else [v])]
 
     # lookup the pipeline for the target sdss_id
     pipes = list(vizdb.SDSSidToAstraPipeline.select().

--- a/python/valis/db/queries.py
+++ b/python/valis/db/queries.py
@@ -1271,6 +1271,7 @@ def get_astra_pipeline(sdss_id: int, release: str, pipeline: str) -> peewee.Mode
         return None
 
     tables = {v._meta.table_name: v for v in astra.__dict__.values() if inspect.isclass(v) and issubclass(v, astra.AstraBase)}
+    tables['apogee_net'] = tables.get('apogee_net', tables.get('apogee_net_v2'))
 
     if pipeline not in tables:
         raise ValueError(f"Astra pipeline {pipeline} not found in astra schema {vastra}.")

--- a/python/valis/routes/target.py
+++ b/python/valis/routes/target.py
@@ -15,9 +15,10 @@ from valis.routes.base import Base
 from valis.cache import valis_cache
 from valis.db.queries import (get_target_meta, get_a_spectrum, get_catalog_sources,
                               get_parent_catalog_data, get_target_cartons,
-                              get_target_pipeline, get_target_by_altid, append_pipes, get_legacy_allspec)
+                              get_target_pipeline, get_target_by_altid, append_pipes, get_legacy_allspec,
+                              get_astra_pipeline)
 from valis.db.db import get_pw_db
-from valis.db.models import CatalogResponse, CartonModel, ParentCatalogModel, PipesModel, SDSSModel, AllSpecModel
+from valis.db.models import CatalogResponse, CartonModel, ParentCatalogModel, PipesModel, SDSSModel, AllSpecModel, AstraPipeline
 from valis.routes.auth import set_auth
 
 
@@ -282,3 +283,25 @@ class Target(Base):
                            ):
         """ Return legacy SDSS information from the allspec table for a given sdss_id """
         return list(get_legacy_allspec(sdss_id, phase=phase).dicts())
+
+    @router.get('/astra/{pipeline}/{sdss_id}',
+                dependencies=[Depends(get_pw_db), Depends(set_auth)],
+                responses={400: {'description': 'Invalid astra pipeline'}},
+                response_model=AstraPipeline,
+                response_model_exclude_unset=True,
+                response_model_exclude_none=True,
+                summary='Retrieve astra pipeline data for a taget by sdss_id')
+    @valis_cache(namespace='valis-target')
+    async def get_astra_pipes(self,
+                          pipeline: Annotated[str, Path(description='The Astra pipeline to search',
+                                                       example='boss_net')],
+                          sdss_id: Annotated[int, Path(description='The sdss_id of the target to get',
+                                                       example=23326)]) -> dict | None:
+        """Return Astra pipeline data for a given sdss_id and pipeline name."""
+
+        try:
+            result = get_astra_pipeline(sdss_id, self.release, pipeline)
+        except Exception as e:
+            raise HTTPException(status_code=400, detail=f'Error: {e}') from e
+
+        return result

--- a/python/valis/routes/target.py
+++ b/python/valis/routes/target.py
@@ -290,7 +290,7 @@ class Target(Base):
                 response_model=AstraPipeline,
                 response_model_exclude_unset=True,
                 response_model_exclude_none=True,
-                summary='Retrieve astra pipeline data for a taget by sdss_id')
+                summary='Retrieve astra pipeline data for a target by sdss_id')
     @valis_cache(namespace='valis-target')
     async def get_astra_pipes(self,
                           pipeline: Annotated[str, Path(description='The Astra pipeline to search',
@@ -301,7 +301,10 @@ class Target(Base):
 
         try:
             result = get_astra_pipeline(sdss_id, self.release, pipeline)
-        except Exception as e:
+        except ValueError as e:
             raise HTTPException(status_code=400, detail=f'Error: {e}') from e
+
+        if result is None:
+            raise HTTPException(status_code=404, detail=f'No Astra pipeline data found for sdss_id {sdss_id} and pipeline {pipeline}')
 
         return result


### PR DESCRIPTION
This PR adds support for retrieving astra pipeline parameters for a given sdss_id.  Two new queries are added:

- `list_astra_pipelines` - returns a list of available pipelines for a given sdss_id and data release
- `get_astra_pipeline` - returns the pipelines parameters for a given sdss_id, data release, and pipeline name. 

The list of pipelines is now included in the returned pipeline info in `target/pipelines/{sdss_id}`, and a new endpoint in the target group is added at `target/astra/{pipeline}/{sdss_id}`.  

Related zora pr https://github.com/sdss/zora/pull/121