### PR TITLE
Tweaks to the pipelines summary call for performance

### DIFF
--- a/python/valis/db/models.py
+++ b/python/valis/db/models.py
@@ -159,10 +159,10 @@ class BossSummary(PeeweeBase):
     id: int = Field(..., description="the unique pk identifier for the boss_spectrum row")
     mjd: int = Field(None, description="the MJD of the observation in boss_spectrum")
     specprimary: Optional[bool] = Field(None, description="flag if this is a primary spectrum")
-    boss_version: Optional[int] = Field(None, exclude=True, description="the boss version info")
+    boss_version: Optional[int] = Field(None, exclude=True, description="the boss version id")
     location: Optional[str] = Field(None, description='the file location')
     field: int = Field(None, description="the observed field id")
-    label: str = Field(None, exclude=True, description="the boss version coadd label")
+    label: Optional[str] = Field(None, exclude=True, description="the boss version coadd label")
 
     @computed_field(description="The access product or file species name")
     @property

--- a/python/valis/db/models.py
+++ b/python/valis/db/models.py
@@ -159,23 +159,24 @@ class BossSummary(PeeweeBase):
     id: int = Field(..., description="the unique pk identifier for the boss_spectrum row")
     mjd: int = Field(None, description="the MJD of the observation in boss_spectrum")
     specprimary: Optional[bool] = Field(None, description="flag if this is a primary spectrum")
-    boss_version: Optional[BossVersion] = Field(None, exclude=True, description="the boss version info")
+    boss_version: Optional[int] = Field(None, exclude=True, description="the boss version info")
     location: Optional[str] = Field(None, description='the file location')
     field: int = Field(None, description="the observed field id")
+    label: str = Field(None, exclude=True, description="the boss version coadd label")
 
     @computed_field(description="The access product or file species name")
     @property
     def product(self) -> str:
         """The access product or file species name"""
         # in case boss_version is None
-        if not self.boss_version:
+        if not self.label:
             return 'specLite'
 
-        if self.boss_version.label == "daily":
+        if self.label == "daily":
             return "specLite"
-        elif self.boss_version.label == "allepoch":
+        elif self.label == "allepoch":
             return "specLite_coadd"
-        elif self.boss_version.label == "epoch":
+        elif self.label == "epoch":
             return "specLite_epoch"
         else:
             return "specLite"
@@ -184,7 +185,7 @@ class BossSummary(PeeweeBase):
     @property
     def coadd(self) -> str:
         """The name of the coadd"""
-        return self.boss_version.label if self.boss_version else None
+        return self.label if self.label else None
 
     @computed_field(description="The filestem of the product")
     @property

--- a/python/valis/db/queries.py
+++ b/python/valis/db/queries.py
@@ -477,7 +477,7 @@ def get_boss_target(
     query = boss.BossSpectrum.select(*fields).where(boss.BossSpectrum.sdss_id == sdss_id, vercond)
 
     # extend with boss version info
-    query = query.select_extend(boss.BossVersion).join(boss.BossVersion,
+    query = query.select_extend(boss.BossVersion.label.alias('label')).join(boss.BossVersion,
                                                        on=(boss.BossSpectrum.boss_version == boss.BossVersion.id))
 
     # filter on primary

--- a/python/valis/db/queries.py
+++ b/python/valis/db/queries.py
@@ -476,6 +476,10 @@ def get_boss_target(
     # query for the target
     query = boss.BossSpectrum.select(*fields).where(boss.BossSpectrum.sdss_id == sdss_id, vercond)
 
+    # extend with boss version info
+    query = query.select_extend(boss.BossVersion).join(boss.BossVersion,
+                                                       on=(boss.BossSpectrum.boss_version == boss.BossVersion.id))
+
     # filter on primary
     if primary:
         query = query.where(boss.BossSpectrum.specprimary == 1)
@@ -490,7 +494,7 @@ def get_boss_target(
 
     # filter on coadd label
     if coadd:
-        query = query.join(boss.BossVersion).where(boss.BossVersion.label == coadd)
+        query = query.where(boss.BossVersion.label == coadd)
 
     # filter on field
     if field:
@@ -643,9 +647,8 @@ def get_pipe_meta(sdss_id: int, release: str, pipeline: str) -> dict:
     # get boss pipeline target
     if pipeline == "boss" and (qq := get_boss_target(sdss_id, release, primary=False)):
         output = {pipeline: [], "files": {pipeline: []}}
-        for item in qq:
-            res = model_to_dict(item)
-            filepath = build_boss_path(res, release=release)
+        for res in qq.dicts().iterator():
+            filepath = build_boss_path(res, release=release, ignore_existence=True)
             res.update({"location": get_pathcomp(filepath, release, "location")})
             output[pipeline].append(res)
             output["files"][pipeline].append(filepath)
@@ -661,17 +664,15 @@ def get_pipe_meta(sdss_id: int, release: str, pipeline: str) -> dict:
 
         # stars
         if (qq := get_apogee_target(sdss_id, release, table='star')):
-            for item in qq:
-                res = model_to_dict(item)
-                filepath = build_apogee_path(res, release=release)
+            for res in qq.dicts().iterator():
+                filepath = build_apogee_path(res, release=release, ignore_existence=True)
                 res.update({"location": get_pathcomp(filepath, release, "location")})
                 output[pipeline]['stars'].append(res)
                 output["files"][pipeline].append(filepath)
         # visits
         if (qq := get_apogee_target(sdss_id, release, table='visit')):
-            for item in qq:
-                res = model_to_dict(item)
-                filepath = build_apogee_path(res, release=release)
+            for res in qq.dicts().iterator():
+                filepath = build_apogee_path(res, release=release, ignore_existence=True)
                 res.update({"location": get_pathcomp(filepath, release, "location")})
                 output[pipeline]['visits'].append(res)
                 output["files"][pipeline].append(filepath)
@@ -682,7 +683,7 @@ def get_pipe_meta(sdss_id: int, release: str, pipeline: str) -> dict:
         res = qq.dicts().first()
         output = {pipeline: {"source": res, 'products': []}, "files": {pipeline: []}}
         for item in ("mwmStar", "mwmVisit"):
-            filepath = build_astra_path(res, release=release, name=item)
+            filepath = build_astra_path(res, release=release, name=item, ignore_existence=True)
             output[pipeline]['products'].append({"product": item, "location": get_pathcomp(filepath, release, "location")})
             output["files"][pipeline].append(filepath)
 

--- a/python/valis/utils/paths.py
+++ b/python/valis/utils/paths.py
@@ -121,7 +121,7 @@ def build_boss_path(values: dict, release: str, lite: bool = True,
         the output file path
     """
     # get coadd label or fallback to daily
-    label = (values and values.get('boss_version', {}).get('label')) or 'daily'
+    label = values.get('label') or 'daily'
     match label:
         case "allepoch":
             suffix = "_coadd"

--- a/python/valis/utils/paths.py
+++ b/python/valis/utils/paths.py
@@ -121,7 +121,7 @@ def build_boss_path(values: dict, release: str, lite: bool = True,
         the output file path
     """
     # get coadd label or fallback to daily
-    label = values.get('label') or 'daily'
+    label = (values and values.get('label')) or 'daily'
     match label:
         case "allepoch":
             suffix = "_coadd"

--- a/python/valis/utils/versions.py
+++ b/python/valis/utils/versions.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 from collections import ChainMap
+from functools import lru_cache
 
 try:
     from datamodel.models import releases
@@ -10,7 +11,7 @@ try:
 except ImportError:
     releases = tags = Release = None
 
-
+@lru_cache(maxsize=32)
 def get_tag_info(release: str) -> dict:
     """ Get the software tag info for a given release
 
@@ -77,6 +78,7 @@ def get_latest_tag_info() -> dict:
     return get_tag_info(rel.name)
 
 
+@lru_cache(maxsize=32)
 def get_tags(release: str) -> dict:
     """ Get the pipeline software tags
 

--- a/uv.lock
+++ b/uv.lock
@@ -6060,7 +6060,7 @@ dependencies = [
 [[package]]
 name = "sdss-solara"
 version = "0.1.0.dev0"
-source = { git = "https://github.com/sdss/sdss_solara?rev=main#a52d698128d47fb0b116e0d974997b9a6376208b" }
+source = { git = "https://github.com/sdss/sdss_solara?rev=main#ded48fb85dfe8d693f572c54c190d17920a93054" }
 dependencies = [
     { name = "jdaviz" },
     { name = "markdown" },


### PR DESCRIPTION
This PR removes use of Peewee's `model_to_dict` as it's extremely slow for serialization.  I only needed it for the BossSpectrum -> BossVersion relationship.  I've moved the boss_version call directly into the peewee query join.  The model now only returns the label, which is really the only thing I was interested in.  I've updated the paths and models accordingly, to account for the change. 